### PR TITLE
chore: update go-webgpu to v0.1.2 and goffi to v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3] - 2025-12-27
+
+### 🔧 Dependencies Update
+
+Hotfix release updating GPU backend dependencies to latest versions.
+
+**Updated Dependencies**:
+- `go-webgpu/webgpu` v0.1.1 → **v0.1.2**
+- `go-webgpu/goffi` v0.3.3 → **v0.3.5**
+
+**Links**:
+- PR: [#21](https://github.com/born-ml/born/pull/21)
+
+---
+
 ## [0.7.2] - 2025-12-24
 
 ### 🔧 Dependencies Update

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 Born is a modern deep learning framework for Go, inspired by [Burn](https://github.com/tracel-ai/burn) (Rust). Build ML models in pure Go and deploy as single binaries - no Python runtime, no complex dependencies.
 
-**Project Status**: 🚀 **v0.7.2 Released!** (Dependencies Update)
-**Latest**: 🔧 Updated go-webgpu v0.1.1, goffi v0.3.3 for improved GPU stability
+**Project Status**: 🚀 **v0.7.3 Released!** (Dependencies Update)
+**Latest**: 🔧 Updated go-webgpu v0.1.2, goffi v0.3.5 for improved GPU stability
 
 *Pure Go ML with GPU acceleration - no CGO required!*
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Approach**: PyTorch-inspired API, Burn-inspired architecture, Go best practices
 > **Philosophy**: Correctness → Performance → Features
 
-**Last Updated**: 2025-12-24 | **Current Version**: v0.7.2 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.2 RELEASED! → v0.8.0 (Feb 2026) → v1.0.0 LTS (After API Freeze)
+**Last Updated**: 2025-12-27 | **Current Version**: v0.7.3 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.3 RELEASED! → v0.8.0 (Feb 2026) → v1.0.0 LTS (After API Freeze)
 
 ---
 
@@ -58,7 +58,7 @@ v0.7.0 (Flash Attention, Speculative Decoding, GGUF) ✅ RELEASED (2025-12-10)
        ↓ (code quality)
 v0.7.1 (Code Quality - Burn Patterns) ✅ RELEASED (2025-12-16)
        ↓ (dependency updates)
-v0.7.2 (Dependencies Update) ✅ CURRENT (2025-12-24)
+v0.7.3 (Dependencies Update) ✅ CURRENT (2025-12-27)
        ↓ (quantization & efficiency)
 v0.8.0 (Quantization, Model Zoo, Jupyter) → Feb 2026
        ↓ (production serving)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/born-ml/born
 go 1.25
 
 require (
-	github.com/go-webgpu/webgpu v0.1.1
+	github.com/go-webgpu/webgpu v0.1.2
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/stretchr/testify v1.11.1
 )
@@ -11,7 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
-	github.com/go-webgpu/goffi v0.3.3 // indirect
+	github.com/go-webgpu/goffi v0.3.5 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/go-webgpu/goffi v0.3.3 h1:sK4nmMYZG6zLTMtSXD8rXlz0PnqZU4y4u0bqmZVEADk=
-github.com/go-webgpu/goffi v0.3.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.1.1 h1:qlG4oZqcAdewGnwBrBawZVSsKyIRiWnWsWMAYaiYEcA=
-github.com/go-webgpu/webgpu v0.1.1/go.mod h1:gdWdzyvKYWZ4cIegCGvUSaMDdD6MppY/sqgecPngHGI=
+github.com/go-webgpu/goffi v0.3.5 h1:9QFC86mGERstCGEwMmpHJvKxtHofCsoxWpl27HZoXFw=
+github.com/go-webgpu/goffi v0.3.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/webgpu v0.1.2 h1:Ng//VzyH1f5fIFzLMtoVQwO8HcVBuUurmqjsJ86QSaU=
+github.com/go-webgpu/webgpu v0.1.2/go.mod h1:HT/5iRK0QtkQjx8DrOEDl4cdDEz2Tdkaksx34UjTEew=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pkoukk/tiktoken-go v0.1.8 h1:85ENo+3FpWgAACBaEUVp+lctuTcYUO7BtmfhlN/QTRo=


### PR DESCRIPTION
## Summary

- Updated `go-webgpu/webgpu` v0.1.1 → **v0.1.2**
- Updated `go-webgpu/goffi` v0.3.3 → **v0.3.5**

## Test plan

- [x] All tests pass
- [x] Linter passes (0 issues)

## Checklist

- [x] `go test ./...` passes
- [x] `make lint` passes
- [x] CHANGELOG.md updated
- [x] README.md updated
- [x] ROADMAP.md updated