### PR TITLE
feat(nn): add WithBias option for Linear layer

### DIFF
--- a/internal/nn/glu_test.go
+++ b/internal/nn/glu_test.go
@@ -305,7 +305,7 @@ func TestSwiGLUFFN_DefaultFFNDim(t *testing.T) {
 func TestNewLinearNoBias(t *testing.T) {
 	backend := autodiff.New(cpu.New())
 
-	linear := newLinearNoBias[Backend](128, 256, backend)
+	linear := NewLinear[Backend](128, 256, backend, WithBias(false))
 
 	// Check parameters
 	params := linear.Parameters()

--- a/nn/nn.go
+++ b/nn/nn.go
@@ -25,14 +25,35 @@ func NewParameter[B tensor.Backend](name string, t *tensor.Tensor[float32, B]) *
 // Linear represents a fully connected (dense) layer.
 type Linear[B tensor.Backend] = nn.Linear[B]
 
+// LinearOption is a functional option for configuring a Linear layer.
+type LinearOption = nn.LinearOption
+
+// WithBias sets whether the Linear layer should use bias.
+//
+// Default is true. Set to false for architectures like LLaMA that don't use bias.
+//
+// Example:
+//
+//	// Linear layer without bias (LLaMA-style)
+//	lm_head := nn.NewLinear(hidden_size, vocab_size, backend, nn.WithBias(false))
+//
+//	// Linear layer with bias (default)
+//	layer := nn.NewLinear(784, 128, backend)  // same as WithBias(true)
+func WithBias(useBias bool) LinearOption {
+	return nn.WithBias(useBias)
+}
+
 // NewLinear creates a new linear layer with Xavier initialization.
 //
 // Example:
 //
 //	backend := cpu.New()
 //	layer := nn.NewLinear(784, 128, backend)
-func NewLinear[B tensor.Backend](inFeatures, outFeatures int, backend B) *Linear[B] {
-	return nn.NewLinear(inFeatures, outFeatures, backend)
+//
+//	// Without bias (for LLaMA, attention projections, etc.)
+//	lm_head := nn.NewLinear(hidden_size, vocab_size, backend, nn.WithBias(false))
+func NewLinear[B tensor.Backend](inFeatures, outFeatures int, backend B, opts ...LinearOption) *Linear[B] {
+	return nn.NewLinear(inFeatures, outFeatures, backend, opts...)
 }
 
 // Conv2D represents a 2D convolutional layer.


### PR DESCRIPTION
## Summary

Add functional options pattern to `NewLinear` for optional bias configuration.

- Add `LinearOption` type and `WithBias(bool)` function
- Add `HasBias()` method for introspection  
- Update `SwiGLUFFN` to use public API (remove internal `newLinearNoBias`)
- Export `WithBias` in public `nn` package

## Usage

```go
// With bias (default, backwards compatible)
layer := nn.NewLinear(784, 128, backend)

// Without bias (for LLaMA-style models, LM head, etc.)
lmHead := nn.NewLinear(hiddenSize, vocabSize, backend, nn.WithBias(false))
```

## Motivation

Many neural network architectures require Linear layers without bias:
- LM Head in language models (GPT, LLaMA, HRM)
- Attention projections (some architectures)
- SwiGLU FFN (already used internally)

## Test plan

- [x] `TestLinear_WithBias` - tests default, explicit true, and false cases
- [x] `TestLinear_NoBias_Forward` - tests forward pass without bias
- [x] `TestLinear_NoBias_StateDict` - tests state dict without bias
- [x] All existing tests pass
- [x] golangci-lint: 0 issues
- [x] Pre-release check passed