### PR TITLE
chore: update go-webgpu to v0.1.4 and goffi to v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.6] - 2026-01-03
+
+### 🔧 ARM64 Darwin Enhancement
+
+Comprehensive ARM64 Darwin support with enhanced struct handling, tested on M3 Pro hardware.
+
+**Updated Dependencies**:
+- `go-webgpu/webgpu` v0.1.3 → **v0.1.4**
+- `go-webgpu/goffi` v0.3.6 → **v0.3.7**
+
+**Improvements**:
+- Proper layout for nested and complex struct types
+- Automatic struct layout computation for integer/float combinations
+- Enhanced struct return handling (9-16 bytes) utilizing X0 and X1 registers
+
+**Fixed Issues**:
+- Resolved segmentation fault in string output benchmarks on Darwin systems
+
+**Contributors**:
+- @ppoage — ARM64 Darwin implementation, Objective-C test suite, assembly verification
+
+**Links**:
+- Upstream release: [go-webgpu v0.1.4](https://github.com/go-webgpu/webgpu/releases/tag/v0.1.4)
+
+---
+
 ## [0.7.5] - 2025-12-29
 
 ### 🔧 ARM64 Hotfix

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/born-ml/born
 go 1.25
 
 require (
-	github.com/go-webgpu/webgpu v0.1.3
+	github.com/go-webgpu/webgpu v0.1.4
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/stretchr/testify v1.11.1
 )
@@ -11,7 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
-	github.com/go-webgpu/goffi v0.3.6 // indirect
+	github.com/go-webgpu/goffi v0.3.7 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/go-webgpu/goffi v0.3.6 h1:OYP7OX48cUcsrHOsTZMBg67hZrA28iDdSuuRDvXgKSM=
-github.com/go-webgpu/goffi v0.3.6/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.1.3 h1:rAcSAgY3H6ucAcoiIYHEEBB6+GMb4oYWbmHRFwkVKIE=
-github.com/go-webgpu/webgpu v0.1.3/go.mod h1:oTWKAiHQtl717uaP8pmETQQorl1sTzGchOM8pal0w6E=
+github.com/go-webgpu/goffi v0.3.7 h1:JqzV4l7PUhJRSsmeyP2vJaIK5ZtSWITwG78iA1E4/AQ=
+github.com/go-webgpu/goffi v0.3.7/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/webgpu v0.1.4 h1:ryaKVNDXzrdE4VInxkzpgs9sLD8IDothoWVxhIltliE=
+github.com/go-webgpu/webgpu v0.1.4/go.mod h1:hi9vqLHfaHeTYZ/R+03WQAs5ovRu6Oi1UL7n9lRFr60=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pkoukk/tiktoken-go v0.1.8 h1:85ENo+3FpWgAACBaEUVp+lctuTcYUO7BtmfhlN/QTRo=


### PR DESCRIPTION
## Summary

Comprehensive ARM64 Darwin support with enhanced struct handling, tested on M3 Pro hardware.

**Updated Dependencies**:
- `go-webgpu/webgpu` v0.1.3 → **v0.1.4**
- `go-webgpu/goffi` v0.3.6 → **v0.3.7**

**Improvements**:
- Proper layout for nested and complex struct types
- Automatic struct layout computation for integer/float combinations
- Enhanced struct return handling (9-16 bytes) utilizing X0 and X1 registers

**Fixed Issues**:
- Resolved segmentation fault in string output benchmarks on Darwin systems

## Test Plan

- [x] All tests pass
- [x] Build succeeds
- [x] golangci-lint passes

## Links

- Upstream release: [go-webgpu v0.1.4](https://github.com/go-webgpu/webgpu/releases/tag/v0.1.4)

## Contributors

- @ppoage — ARM64 Darwin implementation