### PR TITLE
chore: update go-webgpu to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.9] - 2026-02-09
+
+### 🔧 Dependencies Update
+
+Update WebGPU backend to v0.3.0 with new capability-querying API and typed errors.
+
+**Updated Dependencies**:
+- `go-webgpu/webgpu` v0.2.1 → **v0.3.0**
+
+**New Upstream Features Available**:
+- `Surface.GetCapabilities()` — query supported formats, present modes, alpha modes
+- `Device.GetFeatures()` / `Device.HasFeature()` — feature enumeration
+- `Device.GetLimits()` — device limits (experimental)
+- Typed errors with `errors.Is()` / `errors.As()` support (`ErrValidation`, `ErrOutOfMemory`, `ErrInternal`, `ErrDeviceLost`)
+- Resource leak detection via `SetDebugMode(true)` / `ReportLeaks()`
+
+**Links**:
+- Upstream release: [go-webgpu v0.3.0](https://github.com/go-webgpu/webgpu/releases/tag/v0.3.0)
+
+---
+
 ## [0.7.8] - 2026-01-29
 
 ### 🔧 GoGPU Ecosystem Integration (Phase 1)
@@ -1086,6 +1107,13 @@ N/A (initial release)
 
 ---
 
+[0.7.9]: https://github.com/born-ml/born/releases/tag/v0.7.9
+[0.7.8]: https://github.com/born-ml/born/releases/tag/v0.7.8
+[0.7.7]: https://github.com/born-ml/born/releases/tag/v0.7.7
+[0.7.6]: https://github.com/born-ml/born/releases/tag/v0.7.6
+[0.7.5]: https://github.com/born-ml/born/releases/tag/v0.7.5
+[0.7.4]: https://github.com/born-ml/born/releases/tag/v0.7.4
+[0.7.3]: https://github.com/born-ml/born/releases/tag/v0.7.3
 [0.7.2]: https://github.com/born-ml/born/releases/tag/v0.7.2
 [0.7.1]: https://github.com/born-ml/born/releases/tag/v0.7.1
 [0.7.0]: https://github.com/born-ml/born/releases/tag/v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/born-ml/born
 go 1.25
 
 require (
-	github.com/go-webgpu/webgpu v0.2.1
+	github.com/go-webgpu/webgpu v0.3.0
 	github.com/gogpu/gputypes v0.2.0
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM=
 github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.2.1 h1:i4kzvI4oq+ETsMRNbdIIz0eakoUes0yCIlUQgusulbI=
-github.com/go-webgpu/webgpu v0.2.1/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
+github.com/go-webgpu/webgpu v0.3.0 h1:cAZb/FoZzflGCxBJV7Ub8GYkVGgJ1ul3IBDqqRb9RQQ=
+github.com/go-webgpu/webgpu v0.3.0/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
## Summary
- Update `go-webgpu/webgpu` v0.2.1 → **v0.3.0**
- All other dependencies already at latest versions
- No breaking changes affecting born codebase (`PopErrorScope` deprecation not used)

## New upstream features available
- `Surface.GetCapabilities()` — query supported formats, present modes, alpha modes
- `Device.GetFeatures()` / `Device.HasFeature()` — feature enumeration
- `Device.GetLimits()` — device limits (experimental)
- Typed errors with `errors.Is()` / `errors.As()` support
- Resource leak detection via `SetDebugMode(true)` / `ReportLeaks()`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including WebGPU backend tests)
- [x] No deprecated API usage in codebase
