### PR TITLE
chore: update go-webgpu to v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.10] - 2026-02-18
+
+### 🔧 Dependencies Update
+
+Update WebGPU backend to v0.3.1 with critical ARM64 callback fix.
+
+**Updated Dependencies**:
+- `go-webgpu/webgpu` v0.3.0 → **v0.3.1**
+- `go-webgpu/goffi` v0.3.8 → **v0.3.9** (indirect)
+
+**Upstream Fixes**:
+- ARM64 callback trampoline rewrite — fixes LR corruption for callbacks at index > 0
+- Symbol rename to prevent linker collision with purego
+
+**Impact**: Critical fix for macOS Apple Silicon and Linux ARM64 users.
+
+**Links**:
+- Upstream release: [go-webgpu v0.3.1](https://github.com/go-webgpu/webgpu/releases/tag/v0.3.1)
+
+---
+
 ## [0.7.9] - 2026-02-09
 
 ### 🔧 Dependencies Update
@@ -1107,6 +1128,7 @@ N/A (initial release)
 
 ---
 
+[0.7.10]: https://github.com/born-ml/born/releases/tag/v0.7.10
 [0.7.9]: https://github.com/born-ml/born/releases/tag/v0.7.9
 [0.7.8]: https://github.com/born-ml/born/releases/tag/v0.7.8
 [0.7.7]: https://github.com/born-ml/born/releases/tag/v0.7.7

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Approach**: PyTorch-inspired API, Burn-inspired architecture, Go best practices
 > **Philosophy**: Correctness → Performance → Features
 
-**Last Updated**: 2026-01-29 | **Current Version**: v0.7.8 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.8 RELEASED! → v0.8.0 (Feb 2026) → v1.0.0 LTS (After API Freeze)
+**Last Updated**: 2026-02-18 | **Current Version**: v0.7.10 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.10 RELEASED! → v0.8.0 (Feb 2026) → v1.0.0 LTS (After API Freeze)
 
 ---
 
@@ -60,7 +60,9 @@ v0.7.1 (Code Quality - Burn Patterns) ✅ RELEASED (2025-12-16)
        ↓ (dependency updates)
 v0.7.3 (Dependencies Update) ✅ RELEASED (2025-12-27)
        ↓ (ARM64 enhancements, Linear bias option, API improvements, gogpu integration)
-v0.7.8 (GoGPU Ecosystem Integration Phase 1) ✅ CURRENT (2026-01-29)
+v0.7.8 (GoGPU Ecosystem Integration Phase 1) ✅ RELEASED (2026-01-29)
+       ↓ (dependency updates)
+v0.7.10 (ARM64 Callback Fix) ✅ CURRENT (2026-02-18)
        ↓ (quantization & efficiency)
 v0.8.0 (Quantization, Model Zoo, Jupyter) → Feb 2026
        ↓ (production serving)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/born-ml/born
 go 1.25
 
 require (
-	github.com/go-webgpu/webgpu v0.3.0
+	github.com/go-webgpu/webgpu v0.3.1
 	github.com/gogpu/gputypes v0.2.0
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/stretchr/testify v1.11.1
@@ -12,7 +12,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
-	github.com/go-webgpu/goffi v0.3.8 // indirect
+	github.com/go-webgpu/goffi v0.3.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM=
-github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.3.0 h1:cAZb/FoZzflGCxBJV7Ub8GYkVGgJ1ul3IBDqqRb9RQQ=
-github.com/go-webgpu/webgpu v0.3.0/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
+github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc=
+github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/webgpu v0.3.1 h1:GxaJ3Cz2FGzHZ3adAYvuRFTdCMcwrENLbuilyIxSH0o=
+github.com/go-webgpu/webgpu v0.3.1/go.mod h1:lPa1+DhNDB3jb97/KI2ivW+ewK1V9x4k58fObvWBhR4=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
## Summary
- Update `go-webgpu/webgpu` v0.3.0 → **v0.3.1**
- Update `go-webgpu/goffi` v0.3.8 → **v0.3.9** (indirect)

## Upstream fixes
- ARM64 callback trampoline rewrite — fixes LR corruption for callbacks at index > 0
- Symbol rename to prevent linker collision with purego
- Critical for macOS Apple Silicon and Linux ARM64 users

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
