### PR TITLE
chore: update go-webgpu to v0.3.2 (crosscall2 callbacks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.11] - 2026-02-27
+
+### 🔧 Dependencies Update
+
+Update WebGPU backend to v0.3.2 with crosscall2 callback integration.
+
+**Updated Dependencies**:
+- `go-webgpu/webgpu` v0.3.1 → **v0.3.2**
+- `go-webgpu/goffi` v0.3.9 → **v0.4.0** (indirect)
+
+**Upstream Improvements**:
+- crosscall2 integration — callbacks now work from C-library-created threads (Metal, wgpu-native)
+- fakecgo trampoline register fixes synced with purego v0.10.0
+
+**Impact**: Improved callback reliability on macOS Metal and native WebGPU implementations.
+
+**Links**:
+- Upstream release: [go-webgpu v0.3.2](https://github.com/go-webgpu/webgpu/releases/tag/v0.3.2)
+
+---
+
 ## [0.7.10] - 2026-02-18
 
 ### 🔧 Dependencies Update
@@ -18,6 +39,10 @@ Update WebGPU backend to v0.3.1 with critical ARM64 callback fix.
 **Upstream Fixes**:
 - ARM64 callback trampoline rewrite — fixes LR corruption for callbacks at index > 0
 - Symbol rename to prevent linker collision with purego
+
+**Code Quality**:
+- Removed 101 unused `//nolint:gosec` directives (gosec linter updated, no longer flags these)
+- Standardized remaining nolint comments to short format
 
 **Impact**: Critical fix for macOS Apple Silicon and Linux ARM64 users.
 
@@ -1128,6 +1153,10 @@ N/A (initial release)
 
 ---
 
+[0.7.10]: https://github.com/born-ml/born/releases/tag/v0.7.10
+[0.7.9]: https://github.com/born-ml/born/releases/tag/v0.7.9
+[0.7.8]: https://github.com/born-ml/born/releases/tag/v0.7.8
+[0.7.11]: https://github.com/born-ml/born/releases/tag/v0.7.11
 [0.7.10]: https://github.com/born-ml/born/releases/tag/v0.7.10
 [0.7.9]: https://github.com/born-ml/born/releases/tag/v0.7.9
 [0.7.8]: https://github.com/born-ml/born/releases/tag/v0.7.8

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Approach**: PyTorch-inspired API, Burn-inspired architecture, Go best practices
 > **Philosophy**: Correctness → Performance → Features
 
-**Last Updated**: 2026-02-18 | **Current Version**: v0.7.10 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.10 RELEASED! → v0.8.0 (Feb 2026) → v1.0.0 LTS (After API Freeze)
+**Last Updated**: 2026-02-27 | **Current Version**: v0.7.11 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.11 RELEASED! → v0.8.0 (Mar 2026) → v1.0.0 LTS (After API Freeze)
 
 ---
 
@@ -62,7 +62,9 @@ v0.7.3 (Dependencies Update) ✅ RELEASED (2025-12-27)
        ↓ (ARM64 enhancements, Linear bias option, API improvements, gogpu integration)
 v0.7.8 (GoGPU Ecosystem Integration Phase 1) ✅ RELEASED (2026-01-29)
        ↓ (dependency updates)
-v0.7.10 (ARM64 Callback Fix) ✅ CURRENT (2026-02-18)
+v0.7.10 (ARM64 Callback Fix) ✅ RELEASED (2026-02-18)
+       ↓ (callback reliability)
+v0.7.11 (Crosscall2 Callback Integration) ✅ CURRENT (2026-02-27)
        ↓ (quantization & efficiency)
 v0.8.0 (Quantization, Model Zoo, Jupyter) → Feb 2026
        ↓ (production serving)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/born-ml/born
 go 1.25
 
 require (
-	github.com/go-webgpu/webgpu v0.3.1
+	github.com/go-webgpu/webgpu v0.3.2
 	github.com/gogpu/gputypes v0.2.0
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/stretchr/testify v1.11.1
@@ -12,7 +12,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
-	github.com/go-webgpu/goffi v0.3.9 // indirect
+	github.com/go-webgpu/goffi v0.4.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc=
-github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.3.1 h1:GxaJ3Cz2FGzHZ3adAYvuRFTdCMcwrENLbuilyIxSH0o=
-github.com/go-webgpu/webgpu v0.3.1/go.mod h1:lPa1+DhNDB3jb97/KI2ivW+ewK1V9x4k58fObvWBhR4=
+github.com/go-webgpu/goffi v0.4.0 h1:KX/p9hd2n5uqTfDrsiQOU9dOPIsVl/RViY2foFq4r34=
+github.com/go-webgpu/goffi v0.4.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/webgpu v0.3.2 h1:xHhDUxx8xBI8azsnA3D77zzDXJ9GoR7DsB+Hxsp4skM=
+github.com/go-webgpu/webgpu v0.3.2/go.mod h1:eyFh3WTUYDDu2Xv+4F9k+wP6nNoe4rMe28sfIJ20OG4=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/nn/nn_test.go
+++ b/internal/nn/nn_test.go
@@ -452,8 +452,10 @@ func TestInitialization(t *testing.T) {
 	data := w.Raw().AsFloat32()
 
 	// Check all values are within [-bound, bound]
+	// Tolerance accounts for float64→float32 rounding in Xavier()
+	const eps = 1e-6
 	for i, val := range data {
-		if math.Abs(float64(val)) > expectedBound {
+		if math.Abs(float64(val)) > expectedBound+eps {
 			t.Errorf("Xavier init value[%d] = %f exceeds bound %f", i, val, expectedBound)
 		}
 	}


### PR DESCRIPTION
## Summary

Update WebGPU backend to v0.3.2 with crosscall2 callback integration.

**Dependencies updated:**
| Package | Old | New |
|---------|-----|-----|
| `go-webgpu/webgpu` | v0.3.1 | **v0.3.2** |
| `go-webgpu/goffi` | v0.3.9 | **v0.4.0** (indirect) |

**Upstream improvements:**
- crosscall2 integration — callbacks now work from C-library-created threads (Metal, wgpu-native)
- fakecgo trampoline register fixes synced with purego v0.10.0

**Additional fix:**
- Xavier init test: added float32 rounding tolerance (1e-6) to prevent false failures from float64-to-float32 precision loss

**Impact:** Improved callback reliability on macOS Metal and native WebGPU implementations.

Upstream release: https://github.com/go-webgpu/webgpu/releases/tag/v0.3.2