### PR TITLE
chore: update go-webgpu to v0.4.0 (FFI hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.12] - 2026-02-27
+
+### 🔧 Dependencies Update
+
+Update WebGPU backend to v0.4.0 with FFI hardening and improved library loading.
+
+**Updated Dependencies**:
+- `go-webgpu/webgpu` v0.3.2 → **v0.4.0**
+
+**Upstream Improvements**:
+- Null handle guards on 27 public FFI methods — prevents SIGSEGV on nil/released objects
+- `ptrFromUintptr` helper — eliminates all `go vet` unsafe.Pointer warnings
+- `WGPU_NATIVE_PATH` env var for custom wgpu-native library path
+- `loadLibrary` returns `(Library, error)` with proper error propagation
+- Windows DLL eager loading — errors surface at init, not at first use
+- Enhanced `Init()` error messages with library path and remediation suggestions
+- 85 new null guard test cases
+
+**Impact**: Significantly improved safety and debuggability of GPU backend initialization.
+
+**Links**:
+- Upstream release: [go-webgpu v0.4.0](https://github.com/go-webgpu/webgpu/releases/tag/v0.4.0)
+
+---
+
 ## [0.7.11] - 2026-02-27
 
 ### 🔧 Dependencies Update
@@ -1156,6 +1181,7 @@ N/A (initial release)
 [0.7.10]: https://github.com/born-ml/born/releases/tag/v0.7.10
 [0.7.9]: https://github.com/born-ml/born/releases/tag/v0.7.9
 [0.7.8]: https://github.com/born-ml/born/releases/tag/v0.7.8
+[0.7.12]: https://github.com/born-ml/born/releases/tag/v0.7.12
 [0.7.11]: https://github.com/born-ml/born/releases/tag/v0.7.11
 [0.7.10]: https://github.com/born-ml/born/releases/tag/v0.7.10
 [0.7.9]: https://github.com/born-ml/born/releases/tag/v0.7.9

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Approach**: PyTorch-inspired API, Burn-inspired architecture, Go best practices
 > **Philosophy**: Correctness → Performance → Features
 
-**Last Updated**: 2026-02-27 | **Current Version**: v0.7.11 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.11 RELEASED! → v0.8.0 (Mar 2026) → v1.0.0 LTS (After API Freeze)
+**Last Updated**: 2026-02-27 | **Current Version**: v0.7.12 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.12 RELEASED! → v0.8.0 (Mar 2026) → v1.0.0 LTS (After API Freeze)
 
 ---
 
@@ -64,7 +64,9 @@ v0.7.8 (GoGPU Ecosystem Integration Phase 1) ✅ RELEASED (2026-01-29)
        ↓ (dependency updates)
 v0.7.10 (ARM64 Callback Fix) ✅ RELEASED (2026-02-18)
        ↓ (callback reliability)
-v0.7.11 (Crosscall2 Callback Integration) ✅ CURRENT (2026-02-27)
+v0.7.11 (Crosscall2 Callback Integration) ✅ RELEASED (2026-02-27)
+       ↓ (FFI hardening)
+v0.7.12 (FFI Hardening & Library Loading) ✅ CURRENT (2026-02-27)
        ↓ (quantization & efficiency)
 v0.8.0 (Quantization, Model Zoo, Jupyter) → Feb 2026
        ↓ (production serving)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/born-ml/born
 go 1.25
 
 require (
-	github.com/go-webgpu/webgpu v0.3.2
+	github.com/go-webgpu/webgpu v0.4.0
 	github.com/gogpu/gputypes v0.2.0
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/go-webgpu/goffi v0.4.0 h1:KX/p9hd2n5uqTfDrsiQOU9dOPIsVl/RViY2foFq4r34=
 github.com/go-webgpu/goffi v0.4.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.3.2 h1:xHhDUxx8xBI8azsnA3D77zzDXJ9GoR7DsB+Hxsp4skM=
-github.com/go-webgpu/webgpu v0.3.2/go.mod h1:eyFh3WTUYDDu2Xv+4F9k+wP6nNoe4rMe28sfIJ20OG4=
+github.com/go-webgpu/webgpu v0.4.0 h1:ydg61863nHMCvwP/FuAVlf5fwYJIKGhkIprmJJN8aGw=
+github.com/go-webgpu/webgpu v0.4.0/go.mod h1:eyFh3WTUYDDu2Xv+4F9k+wP6nNoe4rMe28sfIJ20OG4=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
## Summary

Update WebGPU backend to v0.4.0 with FFI hardening and improved library loading.

**Dependencies updated:**
| Package | Old | New |
|---------|-----|-----|
| `go-webgpu/webgpu` | v0.3.2 | **v0.4.0** |
| `go-webgpu/goffi` | v0.4.0 | v0.4.0 (unchanged) |

**Upstream improvements:**
- Null handle guards on 27 public FFI methods — prevents SIGSEGV on nil/released objects
- `ptrFromUintptr` helper eliminates all `go vet` unsafe.Pointer warnings
- `WGPU_NATIVE_PATH` env var for custom wgpu-native library path
- `loadLibrary` returns `(Library, error)` with proper error propagation
- Windows DLL eager loading — errors surface at init, not at first use
- Enhanced `Init()` error messages with remediation suggestions
- 85 new null guard test cases upstream

**Impact:** Significantly improved safety and debuggability of GPU backend initialization.

Upstream release: https://github.com/go-webgpu/webgpu/releases/tag/v0.4.0