### PR TITLE
chore: update go-webgpu to v0.4.1 (ABI compliance fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.13] - 2026-03-02
+
+### 🔧 Dependencies Update
+
+Update WebGPU backend to v0.4.1 with critical ABI compliance fixes.
+
+**Updated Dependencies**:
+- `go-webgpu/webgpu` v0.4.0 → **v0.4.1**
+- `go-webgpu/goffi` v0.4.0 → **v0.4.1** (indirect)
+
+**Upstream Bug Fixes (ABI compliance)**:
+- Float32 encoding: correct XMM bit patterns via `math.Float32bits`
+- AMD64 Unix stack: arguments beyond 6 GP registers properly pushed to stack
+- ARM64 Unix stack: arguments beyond 8 GP registers correctly spilled to stack
+- AMD64 struct returns (9-16 bytes): RAX+RDX register pair properly assembled
+- AMD64 sret pointer: structs > 16 bytes use caller buffer as first argument (RDI)
+- ARM64 HFA spilling: Homogeneous Floating-Point Aggregate overflow follows AAPCS64
+
+**Upstream Enhancements**:
+- `runtime.KeepAlive` prevents GC of argument pointers during FFI calls
+- `ErrTooManyArguments` overflow detection for calls exceeding 15 arguments
+
+**Impact**: Critical ABI correctness fixes for multi-platform GPU backend reliability.
+
+**Links**:
+- Upstream release: [go-webgpu v0.4.1](https://github.com/go-webgpu/webgpu/releases/tag/v0.4.1)
+
+---
+
 ## [0.7.12] - 2026-02-27
 
 ### 🔧 Dependencies Update
@@ -1181,6 +1210,7 @@ N/A (initial release)
 [0.7.10]: https://github.com/born-ml/born/releases/tag/v0.7.10
 [0.7.9]: https://github.com/born-ml/born/releases/tag/v0.7.9
 [0.7.8]: https://github.com/born-ml/born/releases/tag/v0.7.8
+[0.7.13]: https://github.com/born-ml/born/releases/tag/v0.7.13
 [0.7.12]: https://github.com/born-ml/born/releases/tag/v0.7.12
 [0.7.11]: https://github.com/born-ml/born/releases/tag/v0.7.11
 [0.7.10]: https://github.com/born-ml/born/releases/tag/v0.7.10

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Approach**: PyTorch-inspired API, Burn-inspired architecture, Go best practices
 > **Philosophy**: Correctness → Performance → Features
 
-**Last Updated**: 2026-02-27 | **Current Version**: v0.7.12 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.12 RELEASED! → v0.8.0 (Mar 2026) → v1.0.0 LTS (After API Freeze)
+**Last Updated**: 2026-03-02 | **Current Version**: v0.7.13 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.13 RELEASED! → v0.8.0 (Mar 2026) → v1.0.0 LTS (After API Freeze)
 
 ---
 
@@ -66,7 +66,9 @@ v0.7.10 (ARM64 Callback Fix) ✅ RELEASED (2026-02-18)
        ↓ (callback reliability)
 v0.7.11 (Crosscall2 Callback Integration) ✅ RELEASED (2026-02-27)
        ↓ (FFI hardening)
-v0.7.12 (FFI Hardening & Library Loading) ✅ CURRENT (2026-02-27)
+v0.7.12 (FFI Hardening & Library Loading) ✅ RELEASED (2026-02-27)
+       ↓ (ABI compliance fixes)
+v0.7.13 (ABI Compliance Fixes) ✅ CURRENT (2026-03-02)
        ↓ (quantization & efficiency)
 v0.8.0 (Quantization, Model Zoo, Jupyter) → Feb 2026
        ↓ (production serving)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/born-ml/born
 go 1.25
 
 require (
-	github.com/go-webgpu/webgpu v0.4.0
+	github.com/go-webgpu/webgpu v0.4.1
 	github.com/gogpu/gputypes v0.2.0
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/stretchr/testify v1.11.1
@@ -12,7 +12,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
-	github.com/go-webgpu/goffi v0.4.0 // indirect
+	github.com/go-webgpu/goffi v0.4.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/go-webgpu/goffi v0.4.0 h1:KX/p9hd2n5uqTfDrsiQOU9dOPIsVl/RViY2foFq4r34=
-github.com/go-webgpu/goffi v0.4.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.4.0 h1:ydg61863nHMCvwP/FuAVlf5fwYJIKGhkIprmJJN8aGw=
-github.com/go-webgpu/webgpu v0.4.0/go.mod h1:eyFh3WTUYDDu2Xv+4F9k+wP6nNoe4rMe28sfIJ20OG4=
+github.com/go-webgpu/goffi v0.4.1 h1:2hQH5XXloxTyTtIleYv+Rajlwzp6UOETURhSZ5+zJxU=
+github.com/go-webgpu/goffi v0.4.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/webgpu v0.4.1 h1:PT9Wb2947qQY1oR5itKWXgieCG/265tUg/762WR6mrU=
+github.com/go-webgpu/webgpu v0.4.1/go.mod h1:wFLIOZByL/XYk1zs6rKUK8WgyMPRf4EIwlcwYb1/BNo=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
## Summary

Update WebGPU backend to v0.4.1 with critical ABI compliance fixes in goffi.

**Dependencies updated:**
| Package | Old | New |
|---------|-----|-----|
| `go-webgpu/webgpu` | v0.4.0 | **v0.4.1** |
| `go-webgpu/goffi` | v0.4.0 | **v0.4.1** (indirect) |

**Upstream bug fixes (ABI compliance):**
- Float32 encoding: correct XMM bit patterns via `math.Float32bits`
- AMD64 Unix stack: arguments beyond 6 GP registers properly pushed to stack
- ARM64 Unix stack: arguments beyond 8 GP registers correctly spilled to stack
- AMD64 struct returns (9-16 bytes): RAX+RDX register pair properly assembled
- AMD64 sret pointer: structs > 16 bytes use caller buffer as first argument (RDI)
- ARM64 HFA spilling: Homogeneous Floating-Point Aggregate overflow follows AAPCS64

**Upstream enhancements:**
- `runtime.KeepAlive` prevents GC of argument pointers during FFI calls
- `ErrTooManyArguments` overflow detection for calls exceeding 15 arguments

**Impact:** Critical ABI correctness for multi-platform GPU backend reliability.

Upstream release: https://github.com/go-webgpu/webgpu/releases/tag/v0.4.1