### PR TITLE
chore: release v0.7.14 — ONNX Equal operator (community)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.14] - 2026-03-04
+
+### 🎉 Community Contribution — ONNX Equal Operator
+
+First external contribution! Thanks to [@jsully1720](https://github.com/jsully1720).
+
+**Added**:
+- ONNX `Equal` operator — binary element-wise comparison returning bool tensor
+- New `comparison_ops.go` category for ONNX comparison operators
+- `registerComparisonOps()` wired into operator registry
+
+**ONNX operators**: 38 → 39
+
+**Links**:
+- PR: [#34](https://github.com/born-ml/born/pull/34) by @jsully1720
+- Issue: [#35](https://github.com/born-ml/born/issues/35)
+
+---
+
 ## [0.7.13] - 2026-03-02
 
 ### 🔧 Dependencies Update
@@ -1210,6 +1229,7 @@ N/A (initial release)
 [0.7.10]: https://github.com/born-ml/born/releases/tag/v0.7.10
 [0.7.9]: https://github.com/born-ml/born/releases/tag/v0.7.9
 [0.7.8]: https://github.com/born-ml/born/releases/tag/v0.7.8
+[0.7.14]: https://github.com/born-ml/born/releases/tag/v0.7.14
 [0.7.13]: https://github.com/born-ml/born/releases/tag/v0.7.13
 [0.7.12]: https://github.com/born-ml/born/releases/tag/v0.7.12
 [0.7.11]: https://github.com/born-ml/born/releases/tag/v0.7.11

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Approach**: PyTorch-inspired API, Burn-inspired architecture, Go best practices
 > **Philosophy**: Correctness → Performance → Features
 
-**Last Updated**: 2026-03-02 | **Current Version**: v0.7.13 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.13 RELEASED! → v0.8.0 (Mar 2026) → v1.0.0 LTS (After API Freeze)
+**Last Updated**: 2026-03-04 | **Current Version**: v0.7.14 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.14 RELEASED! → v0.8.0 (Mar 2026) → v1.0.0 LTS (After API Freeze)
 
 ---
 
@@ -68,7 +68,9 @@ v0.7.11 (Crosscall2 Callback Integration) ✅ RELEASED (2026-02-27)
        ↓ (FFI hardening)
 v0.7.12 (FFI Hardening & Library Loading) ✅ RELEASED (2026-02-27)
        ↓ (ABI compliance fixes)
-v0.7.13 (ABI Compliance Fixes) ✅ CURRENT (2026-03-02)
+v0.7.13 (ABI Compliance Fixes) ✅ RELEASED (2026-03-02)
+       ↓ (first community contribution)
+v0.7.14 (ONNX Equal — Community PR) ✅ CURRENT (2026-03-04)
        ↓ (quantization & efficiency)
 v0.8.0 (Quantization, Model Zoo, Jupyter) → Feb 2026
        ↓ (production serving)


### PR DESCRIPTION
## Summary

- Release v0.7.14 documentation update
- First external contribution by @jsully1720 (ONNX Equal operator, PR #34)
- ONNX operators: 38 → 39

## Changes

- CHANGELOG.md: v0.7.14 entry with community contribution details
- ROADMAP.md: version header and graph updated to v0.7.14

## Test plan

- [ ] CI passes (no code changes, docs only)