### PR TITLE
chore: release v0.7.15 — Erf operator (community)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.15] - 2026-04-07
+
+### 🎉 Community Contribution — Erf Operator
+
+Second external contribution! Thanks to [@bennibbelink](https://github.com/bennibbelink).
+
+**Added**:
+- `Erf` (error function) operator — full vertical slice across the entire stack
+- Backend interface: `Erf(x *RawTensor) *RawTensor`
+- CPU backend: `math.Erf` for float32/float64
+- WebGPU backend: Abramowitz & Stegun polynomial approximation shader
+- Autodiff: backward pass with correct derivative `2/√π · exp(-x²)`
+- Mock backend, Tensor API (`tensor.Erf()`)
+- Comprehensive tests: forward + backward, float32/float64, edge cases (Inf, NaN)
+
+**Links**:
+- PR: [#37](https://github.com/born-ml/born/pull/37) by @bennibbelink
+
+---
+
 ## [0.7.14] - 2026-03-04
 
 ### 🎉 Community Contribution — ONNX Equal Operator
@@ -1229,6 +1249,7 @@ N/A (initial release)
 [0.7.10]: https://github.com/born-ml/born/releases/tag/v0.7.10
 [0.7.9]: https://github.com/born-ml/born/releases/tag/v0.7.9
 [0.7.8]: https://github.com/born-ml/born/releases/tag/v0.7.8
+[0.7.15]: https://github.com/born-ml/born/releases/tag/v0.7.15
 [0.7.14]: https://github.com/born-ml/born/releases/tag/v0.7.14
 [0.7.13]: https://github.com/born-ml/born/releases/tag/v0.7.13
 [0.7.12]: https://github.com/born-ml/born/releases/tag/v0.7.12

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Approach**: PyTorch-inspired API, Burn-inspired architecture, Go best practices
 > **Philosophy**: Correctness → Performance → Features
 
-**Last Updated**: 2026-03-04 | **Current Version**: v0.7.14 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.14 RELEASED! → v0.8.0 (Mar 2026) → v1.0.0 LTS (After API Freeze)
+**Last Updated**: 2026-04-07 | **Current Version**: v0.7.15 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.7.15 RELEASED! → v0.8.0 → v1.0.0 LTS (After API Freeze)
 
 ---
 
@@ -70,7 +70,9 @@ v0.7.12 (FFI Hardening & Library Loading) ✅ RELEASED (2026-02-27)
        ↓ (ABI compliance fixes)
 v0.7.13 (ABI Compliance Fixes) ✅ RELEASED (2026-03-02)
        ↓ (first community contribution)
-v0.7.14 (ONNX Equal — Community PR) ✅ CURRENT (2026-03-04)
+v0.7.14 (ONNX Equal — Community PR) ✅ RELEASED (2026-03-04)
+       ↓ (erf operator — community contribution)
+v0.7.15 (Erf Operator — Community PR) ✅ CURRENT (2026-04-07)
        ↓ (quantization & efficiency)
 v0.8.0 (Quantization, Model Zoo, Jupyter) → Feb 2026
        ↓ (production serving)


### PR DESCRIPTION
## Summary

- Release v0.7.15 documentation update
- Second external contribution by @bennibbelink (Erf operator, PR #37)
- Full vertical slice: Backend, CPU, WebGPU shader, Autodiff, Mock, Tensor API, tests

## Changes

- CHANGELOG.md: v0.7.15 entry
- ROADMAP.md: version header and graph updated

## Test plan

- [ ] CI passes (docs only, no code changes)