### PR TITLE
refactor: introduce ConvDims and PoolDims parameter structs to reduce code complexity

### DIFF
--- a/internal/autodiff/ops/maxpool2d.go
+++ b/internal/autodiff/ops/maxpool2d.go
@@ -1,6 +1,7 @@
 package ops
 
 import (
+	"github.com/born-ml/born/internal/backend/cpu"
 	"github.com/born-ml/born/internal/tensor"
 )
 
@@ -61,12 +62,19 @@ func computeMaxIndices(input, output *tensor.RawTensor, kernelSize, stride int) 
 	numOutputs := N * C * HOut * WOut
 	maxIndices := make([]int, numOutputs)
 
+	poolDims := &cpu.PoolDims{
+		N: N, C: C, H: H, W: W,
+		KH: kernelSize, KW: kernelSize,
+		HOut: HOut, WOut: WOut,
+		Stride: stride,
+	}
+
 	// Compute max indices based on dtype
 	switch input.DType() {
 	case tensor.Float32:
-		computeMaxIndicesFloat32(maxIndices, input, N, C, H, W, HOut, WOut, kernelSize, stride)
+		computeMaxIndicesFloat32(maxIndices, input, poolDims)
 	case tensor.Float64:
-		computeMaxIndicesFloat64(maxIndices, input, N, C, H, W, HOut, WOut, kernelSize, stride)
+		computeMaxIndicesFloat64(maxIndices, input, poolDims)
 	default:
 		panic("MaxPool2D: unsupported dtype")
 	}
@@ -75,8 +83,17 @@ func computeMaxIndices(input, output *tensor.RawTensor, kernelSize, stride int) 
 }
 
 // computeMaxIndicesFloat32 finds max positions for float32 tensors.
-func computeMaxIndicesFloat32(maxIndices []int, input *tensor.RawTensor, N, C, H, W, HOut, WOut, kernelSize, stride int) {
+func computeMaxIndicesFloat32(maxIndices []int, input *tensor.RawTensor, dims *cpu.PoolDims) {
 	inputData := input.AsFloat32()
+
+	N := dims.N
+	C := dims.C
+	H := dims.H
+	W := dims.W
+	HOut := dims.HOut
+	WOut := dims.WOut
+	kernelSize := dims.KH
+	stride := dims.Stride
 
 	outIdx := 0
 	for n := 0; n < N; n++ {
@@ -114,8 +131,17 @@ func computeMaxIndicesFloat32(maxIndices []int, input *tensor.RawTensor, N, C, H
 }
 
 // computeMaxIndicesFloat64 finds max positions for float64 tensors.
-func computeMaxIndicesFloat64(maxIndices []int, input *tensor.RawTensor, N, C, H, W, HOut, WOut, kernelSize, stride int) {
+func computeMaxIndicesFloat64(maxIndices []int, input *tensor.RawTensor, dims *cpu.PoolDims) {
 	inputData := input.AsFloat64()
+
+	N := dims.N
+	C := dims.C
+	H := dims.H
+	W := dims.W
+	HOut := dims.HOut
+	WOut := dims.WOut
+	kernelSize := dims.KH
+	stride := dims.Stride
 
 	outIdx := 0
 	for n := 0; n < N; n++ {

--- a/internal/autodiff/ops/maxpool2d_test.go
+++ b/internal/autodiff/ops/maxpool2d_test.go
@@ -284,3 +284,48 @@ func TestMaxPool2DOp_Float64(t *testing.T) {
 
 	t.Log("SUCCESS: Float64 gradients correct")
 }
+
+func BenchmarkMaxPool2D_Backward_Batch(b *testing.B) {
+	backend := cpu.New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{64, 1, 28, 28}, tensor.Float32, tensor.CPU)
+	grad, _ := tensor.NewRaw(tensor.Shape{64, 1, 14, 14}, tensor.Float32, tensor.CPU)
+
+	output := backend.MaxPool2D(input, 2, 2)
+	op := NewMaxPool2DOp(input, output, 2, 2)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.MaxPool2DBackward(input, grad, op.maxIndices, 2, 2)
+	}
+}
+
+func BenchmarkMaxPool2D_Backward_MultiChannel(b *testing.B) {
+	backend := cpu.New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{1, 16, 14, 14}, tensor.Float32, tensor.CPU)
+	grad, _ := tensor.NewRaw(tensor.Shape{1, 16, 12, 12}, tensor.Float32, tensor.CPU)
+
+	output := backend.MaxPool2D(input, 3, 1)
+	op := NewMaxPool2DOp(input, output, 3, 1)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.MaxPool2DBackward(input, grad, op.maxIndices, 3, 1)
+	}
+}
+
+func BenchmarkMaxPool2D_Backward_Deep(b *testing.B) {
+	backend := cpu.New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{8, 64, 14, 14}, tensor.Float32, tensor.CPU)
+	grad, _ := tensor.NewRaw(tensor.Shape{8, 64, 12, 12}, tensor.Float32, tensor.CPU)
+
+	output := backend.MaxPool2D(input, 3, 1)
+	op := NewMaxPool2DOp(input, output, 3, 1)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.MaxPool2DBackward(input, grad, op.maxIndices, 3, 1)
+	}
+}

--- a/internal/autodiff/ops/maxpool2d_test.go
+++ b/internal/autodiff/ops/maxpool2d_test.go
@@ -288,8 +288,8 @@ func TestMaxPool2DOp_Float64(t *testing.T) {
 func BenchmarkMaxPool2D_Backward_Batch(b *testing.B) {
 	backend := cpu.New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{64, 1, 28, 28}, tensor.Float32, tensor.CPU)
-	grad, _ := tensor.NewRaw(tensor.Shape{64, 1, 14, 14}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{64, 1, 28, 28}, backend).Raw()
+	grad := tensor.Randn[float32](tensor.Shape{64, 1, 14, 14}, backend).Raw()
 
 	output := backend.MaxPool2D(input, 2, 2)
 	op := NewMaxPool2DOp(input, output, 2, 2)
@@ -303,8 +303,8 @@ func BenchmarkMaxPool2D_Backward_Batch(b *testing.B) {
 func BenchmarkMaxPool2D_Backward_MultiChannel(b *testing.B) {
 	backend := cpu.New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{1, 16, 14, 14}, tensor.Float32, tensor.CPU)
-	grad, _ := tensor.NewRaw(tensor.Shape{1, 16, 12, 12}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{1, 16, 14, 14}, backend).Raw()
+	grad := tensor.Randn[float32](tensor.Shape{1, 16, 12, 12}, backend).Raw()
 
 	output := backend.MaxPool2D(input, 3, 1)
 	op := NewMaxPool2DOp(input, output, 3, 1)
@@ -318,8 +318,8 @@ func BenchmarkMaxPool2D_Backward_MultiChannel(b *testing.B) {
 func BenchmarkMaxPool2D_Backward_Deep(b *testing.B) {
 	backend := cpu.New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{8, 64, 14, 14}, tensor.Float32, tensor.CPU)
-	grad, _ := tensor.NewRaw(tensor.Shape{8, 64, 12, 12}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{8, 64, 14, 14}, backend).Raw()
+	grad := tensor.Randn[float32](tensor.Shape{8, 64, 12, 12}, backend).Raw()
 
 	output := backend.MaxPool2D(input, 3, 1)
 	op := NewMaxPool2DOp(input, output, 3, 1)

--- a/internal/backend/cpu/conv2d.go
+++ b/internal/backend/cpu/conv2d.go
@@ -6,6 +6,14 @@ import (
 	"github.com/born-ml/born/internal/tensor"
 )
 
+// ConvDims groups convolution dimension parameters.
+type ConvDims struct {
+	N, CIn, H, W    int // Input dimensions
+	COut, KH, KW    int // Kernel dimensions
+	HOut, WOut      int // Output dimensions
+	Stride, Padding int // Convolution parameters
+}
+
 // Conv2D performs 2D convolution using im2col algorithm.
 //
 // Input shape: [batch, in_channels, height, width]
@@ -73,12 +81,19 @@ func (cpu *CPUBackend) Conv2D(input, kernel *tensor.RawTensor, stride, padding i
 		panic(fmt.Sprintf("conv2d: failed to create output tensor: %v", err))
 	}
 
+	convDims := &ConvDims{
+		N: N, CIn: CIn, H: H, W: W,
+		COut: COut, KH: KH, KW: KW,
+		HOut: HOut, WOut: WOut,
+		Stride: stride, Padding: padding,
+	}
+
 	// Dispatch to type-specific implementation
 	switch input.DType() {
 	case tensor.Float32:
-		conv2dFloat32(output, input, kernel, N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding)
+		conv2dFloat32(output, input, kernel, convDims)
 	case tensor.Float64:
-		conv2dFloat64(output, input, kernel, N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding)
+		conv2dFloat64(output, input, kernel, convDims)
 	default:
 		panic(fmt.Sprintf("conv2d: unsupported dtype %s", input.DType()))
 	}
@@ -95,31 +110,38 @@ func (cpu *CPUBackend) Conv2D(input, kernel *tensor.RawTensor, stride, padding i
 //  4. Reshape: [C_out, N*H_out*W_out] -> [N, C_out, H_out, W_out]
 //
 // Stride specialization: separate path for stride=1 enables compiler optimizations (SIMD).
-func conv2dFloat32(output, input, kernel *tensor.RawTensor, N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding int) {
+func conv2dFloat32(output, input, kernel *tensor.RawTensor, dims *ConvDims) {
 	// Dispatch to specialized implementation for common case
-	if stride == 1 && padding == 0 {
-		conv2dFloat32Stride1NoPad(output, input, kernel, N, CIn, H, W, COut, KH, KW, HOut, WOut)
+	if dims.Stride == 1 && dims.Padding == 0 {
+		conv2dFloat32Stride1NoPad(output, input, kernel, dims)
 		return
 	}
 
 	// General case (stride > 1 or padding > 0)
-	conv2dFloat32General(output, input, kernel, N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding)
+	conv2dFloat32General(output, input, kernel, dims)
 }
 
 // conv2dFloat32Stride1NoPad is optimized for stride=1, padding=0 (most common case).
 // Compiler can better optimize this with hardcoded stride=1 (loop unrolling, SIMD).
-func conv2dFloat32Stride1NoPad(output, input, kernel *tensor.RawTensor, N, CIn, H, W, COut, KH, KW, HOut, WOut int) {
+func conv2dFloat32Stride1NoPad(output, input, kernel *tensor.RawTensor, dims *ConvDims) {
 	inputData := input.AsFloat32()
 	kernelData := kernel.AsFloat32()
 	outputData := output.AsFloat32()
+
+	N := dims.N
+	CIn := dims.CIn
+	COut := dims.COut
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
 
 	// Step 1: Im2col with stride=1, padding=0
 	colWidth := CIn * KH * KW
 	colHeight := N * HOut * WOut
 	colBuf := make([]float32, colHeight*colWidth)
 
-	im2colFloat32Stride1NoPad(colBuf, inputData, N, CIn, H, W, KH, KW, HOut, WOut)
-
+	im2colFloat32Stride1NoPad(colBuf, inputData, dims)
 	// Step 2: Matrix multiplication
 	for i := 0; i < COut; i++ {
 		for j := 0; j < colHeight; j++ {
@@ -149,10 +171,18 @@ func conv2dFloat32Stride1NoPad(output, input, kernel *tensor.RawTensor, N, CIn, 
 }
 
 // conv2dFloat32General handles arbitrary stride and padding.
-func conv2dFloat32General(output, input, kernel *tensor.RawTensor, N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding int) {
+func conv2dFloat32General(output, input, kernel *tensor.RawTensor, dims *ConvDims) {
 	inputData := input.AsFloat32()
 	kernelData := kernel.AsFloat32()
 	outputData := output.AsFloat32()
+
+	N := dims.N
+	CIn := dims.CIn
+	COut := dims.COut
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
 
 	// Step 1: Im2col transformation
 	// colBuf: [N * H_out * W_out, C_in * K_h * K_w]
@@ -160,7 +190,7 @@ func conv2dFloat32General(output, input, kernel *tensor.RawTensor, N, CIn, H, W,
 	colHeight := N * HOut * WOut
 	colBuf := make([]float32, colHeight*colWidth)
 
-	im2colFloat32(colBuf, inputData, N, CIn, H, W, KH, KW, HOut, WOut, stride, padding)
+	im2colFloat32(colBuf, inputData, dims)
 
 	// Step 2: Reshape kernel
 	// kernelData is already in [C_out, C_in * K_h * K_w] layout (row-major)
@@ -209,13 +239,22 @@ func conv2dFloat32General(output, input, kernel *tensor.RawTensor, N, CIn, H, W,
 
 // im2colFloat32Stride1NoPad is optimized for stride=1, padding=0.
 // Compiler can better optimize with hardcoded stride=1 (no bounds checks for padding).
-func im2colFloat32Stride1NoPad(colBuf, inputData []float32, N, C, H, W, KH, KW, HOut, WOut int) {
-	colWidth := C * KH * KW
+func im2colFloat32Stride1NoPad(colBuf, inputData []float32, dims *ConvDims) {
+	N := dims.N
+	CIn := dims.CIn
+	H := dims.H
+	W := dims.W
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
+
+	colWidth := CIn * KH * KW
 	colIdx := 0
 
 	for n := 0; n < N; n++ {
-		batchOffset := n * C * H * W
-		batchData := inputData[batchOffset : batchOffset+C*H*W]
+		batchOffset := n * CIn * H * W
+		batchData := inputData[batchOffset : batchOffset+CIn*H*W]
 
 		for outH := 0; outH < HOut; outH++ {
 			for outW := 0; outW < WOut; outW++ {
@@ -224,7 +263,7 @@ func im2colFloat32Stride1NoPad(colBuf, inputData []float32, N, C, H, W, KH, KW, 
 				rowData := colBuf[rowOffset : rowOffset+colWidth]
 
 				bufIdx := 0
-				for c := 0; c < C; c++ {
+				for c := 0; c < CIn; c++ {
 					channelOffset := c * H * W
 					channelData := batchData[channelOffset : channelOffset+H*W]
 
@@ -256,14 +295,25 @@ func im2colFloat32Stride1NoPad(colBuf, inputData []float32, N, C, H, W, KH, KW, 
 // For each output position (n, out_h, out_w):
 //   - Extract the patch from input
 //   - Flatten the patch into a row of colBuf
-func im2colFloat32(colBuf, inputData []float32, N, C, H, W, KH, KW, HOut, WOut, stride, padding int) {
-	colWidth := C * KH * KW
+func im2colFloat32(colBuf, inputData []float32, dims *ConvDims) {
+	N := dims.N
+	CIn := dims.CIn
+	H := dims.H
+	W := dims.W
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
+	stride := dims.Stride
+	padding := dims.Padding
+
+	colWidth := CIn * KH * KW
 	colIdx := 0 // Current row in colBuf
 
 	for n := 0; n < N; n++ {
 		// Pre-slice batch: eliminates n*C*H*W bounds check
-		batchOffset := n * C * H * W
-		batchData := inputData[batchOffset : batchOffset+C*H*W]
+		batchOffset := n * CIn * H * W
+		batchData := inputData[batchOffset : batchOffset+CIn*H*W]
 
 		for outH := 0; outH < HOut; outH++ {
 			for outW := 0; outW < WOut; outW++ {
@@ -277,7 +327,7 @@ func im2colFloat32(colBuf, inputData []float32, N, C, H, W, KH, KW, HOut, WOut, 
 				rowData := colBuf[rowOffset : rowOffset+colWidth]
 
 				bufIdx := 0
-				for c := 0; c < C; c++ {
+				for c := 0; c < CIn; c++ {
 					// Pre-slice channel: eliminates c*H*W bounds check
 					channelOffset := c * H * W
 					channelData := batchData[channelOffset : channelOffset+H*W]
@@ -308,30 +358,37 @@ func im2colFloat32(colBuf, inputData []float32, N, C, H, W, KH, KW, HOut, WOut, 
 
 // conv2dFloat64 performs Conv2D for float64 using im2col.
 // Stride specialization: separate path for stride=1 enables compiler optimizations (SIMD).
-func conv2dFloat64(output, input, kernel *tensor.RawTensor, N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding int) {
+func conv2dFloat64(output, input, kernel *tensor.RawTensor, dims *ConvDims) {
 	// Dispatch to specialized implementation for common case
-	if stride == 1 && padding == 0 {
-		conv2dFloat64Stride1NoPad(output, input, kernel, N, CIn, H, W, COut, KH, KW, HOut, WOut)
+	if dims.Stride == 1 && dims.Padding == 0 {
+		conv2dFloat64Stride1NoPad(output, input, kernel, dims)
 		return
 	}
 
 	// General case (stride > 1 or padding > 0)
-	conv2dFloat64General(output, input, kernel, N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding)
+	conv2dFloat64General(output, input, kernel, dims)
 }
 
 // conv2dFloat64Stride1NoPad is optimized for stride=1, padding=0 (most common case).
 // Compiler can better optimize this with hardcoded stride=1 (loop unrolling, SIMD).
-func conv2dFloat64Stride1NoPad(output, input, kernel *tensor.RawTensor, N, CIn, H, W, COut, KH, KW, HOut, WOut int) {
+func conv2dFloat64Stride1NoPad(output, input, kernel *tensor.RawTensor, dims *ConvDims) {
 	inputData := input.AsFloat64()
 	kernelData := kernel.AsFloat64()
 	outputData := output.AsFloat64()
+
+	N := dims.N
+	CIn := dims.CIn
+	COut := dims.COut
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
 
 	// Im2col with stride=1, padding=0
 	colWidth := CIn * KH * KW
 	colHeight := N * HOut * WOut
 	colBuf := make([]float64, colHeight*colWidth)
-	im2colFloat64Stride1NoPad(colBuf, inputData, N, CIn, H, W, KH, KW, HOut, WOut)
-
+	im2colFloat64Stride1NoPad(colBuf, inputData, dims)
 	// MatMul
 	for i := 0; i < COut; i++ {
 		for j := 0; j < colHeight; j++ {
@@ -360,17 +417,24 @@ func conv2dFloat64Stride1NoPad(output, input, kernel *tensor.RawTensor, N, CIn, 
 }
 
 // conv2dFloat64General handles arbitrary stride and padding.
-func conv2dFloat64General(output, input, kernel *tensor.RawTensor, N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding int) {
+func conv2dFloat64General(output, input, kernel *tensor.RawTensor, dims *ConvDims) {
 	inputData := input.AsFloat64()
 	kernelData := kernel.AsFloat64()
 	outputData := output.AsFloat64()
+
+	N := dims.N
+	CIn := dims.CIn
+	COut := dims.COut
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
 
 	// Im2col
 	colWidth := CIn * KH * KW
 	colHeight := N * HOut * WOut
 	colBuf := make([]float64, colHeight*colWidth)
-	im2colFloat64(colBuf, inputData, N, CIn, H, W, KH, KW, HOut, WOut, stride, padding)
-
+	im2colFloat64(colBuf, inputData, dims)
 	// MatMul
 	for i := 0; i < COut; i++ {
 		for j := 0; j < colHeight; j++ {
@@ -400,13 +464,22 @@ func conv2dFloat64General(output, input, kernel *tensor.RawTensor, N, CIn, H, W,
 
 // im2colFloat64Stride1NoPad is optimized for stride=1, padding=0.
 // Compiler can better optimize with hardcoded stride=1 (no bounds checks for padding).
-func im2colFloat64Stride1NoPad(colBuf, inputData []float64, N, C, H, W, KH, KW, HOut, WOut int) {
-	colWidth := C * KH * KW
+func im2colFloat64Stride1NoPad(colBuf, inputData []float64, dims *ConvDims) {
+	N := dims.N
+	CIn := dims.CIn
+	H := dims.H
+	W := dims.W
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
+
+	colWidth := CIn * KH * KW
 	colIdx := 0
 
 	for n := 0; n < N; n++ {
-		batchOffset := n * C * H * W
-		batchData := inputData[batchOffset : batchOffset+C*H*W]
+		batchOffset := n * CIn * H * W
+		batchData := inputData[batchOffset : batchOffset+CIn*H*W]
 
 		for outH := 0; outH < HOut; outH++ {
 			for outW := 0; outW < WOut; outW++ {
@@ -415,7 +488,7 @@ func im2colFloat64Stride1NoPad(colBuf, inputData []float64, N, C, H, W, KH, KW, 
 				rowData := colBuf[rowOffset : rowOffset+colWidth]
 
 				bufIdx := 0
-				for c := 0; c < C; c++ {
+				for c := 0; c < CIn; c++ {
 					channelOffset := c * H * W
 					channelData := batchData[channelOffset : channelOffset+H*W]
 
@@ -436,14 +509,25 @@ func im2colFloat64Stride1NoPad(colBuf, inputData []float64, N, C, H, W, KH, KW, 
 	}
 }
 
-func im2colFloat64(colBuf, inputData []float64, N, C, H, W, KH, KW, HOut, WOut, stride, padding int) {
-	colWidth := C * KH * KW
+func im2colFloat64(colBuf, inputData []float64, dims *ConvDims) {
+	N := dims.N
+	CIn := dims.CIn
+	H := dims.H
+	W := dims.W
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
+	stride := dims.Stride
+	padding := dims.Padding
+
+	colWidth := CIn * KH * KW
 	colIdx := 0
 
 	for n := 0; n < N; n++ {
-		// Pre-slice batch: eliminates n*C*H*W bounds check
-		batchOffset := n * C * H * W
-		batchData := inputData[batchOffset : batchOffset+C*H*W]
+		// Pre-slice batch: eliminates n*CIn*H*W bounds check
+		batchOffset := n * CIn * H * W
+		batchData := inputData[batchOffset : batchOffset+CIn*H*W]
 
 		for outH := 0; outH < HOut; outH++ {
 			for outW := 0; outW < WOut; outW++ {
@@ -455,7 +539,7 @@ func im2colFloat64(colBuf, inputData []float64, N, C, H, W, KH, KW, HOut, WOut, 
 				rowData := colBuf[rowOffset : rowOffset+colWidth]
 
 				bufIdx := 0
-				for c := 0; c < C; c++ {
+				for c := 0; c < CIn; c++ {
 					// Pre-slice channel: eliminates c*H*W bounds check
 					channelOffset := c * H * W
 					channelData := batchData[channelOffset : channelOffset+H*W]

--- a/internal/backend/cpu/conv2d_backward.go
+++ b/internal/backend/cpu/conv2d_backward.go
@@ -40,32 +40,37 @@ func (cpu *CPUBackend) Conv2DInputBackward(input, kernel, grad *tensor.RawTensor
 		panic(fmt.Sprintf("Conv2DInputBackward: failed to create gradient tensor: %v", err))
 	}
 
+	convDims := &ConvDims{
+		N: N, CIn: CIn, H: H, W: W,
+		COut: COut, KH: KH, KW: KW,
+		HOut: HOut, WOut: WOut,
+		Stride: stride, Padding: padding,
+	}
+
 	// Dispatch by dtype and stride (stride specialization for compiler optimization)
 	switch grad.DType() {
 	case tensor.Float32:
 		if stride == 1 && padding == 0 {
 			conv2dInputBackwardFloat32Stride1NoPad(
 				inputGrad, grad, kernel,
-				N, CIn, H, W, COut, KH, KW, HOut, WOut,
+				convDims,
 			)
 		} else {
 			conv2dInputBackwardFloat32(
 				inputGrad, grad, kernel,
-				N, CIn, H, W, COut, KH, KW, HOut, WOut,
-				stride, padding,
+				convDims,
 			)
 		}
 	case tensor.Float64:
 		if stride == 1 && padding == 0 {
 			conv2dInputBackwardFloat64Stride1NoPad(
 				inputGrad, grad, kernel,
-				N, CIn, H, W, COut, KH, KW, HOut, WOut,
+				convDims,
 			)
 		} else {
 			conv2dInputBackwardFloat64(
 				inputGrad, grad, kernel,
-				N, CIn, H, W, COut, KH, KW, HOut, WOut,
-				stride, padding,
+				convDims,
 			)
 		}
 	default:
@@ -80,11 +85,23 @@ func (cpu *CPUBackend) Conv2DInputBackward(input, kernel, grad *tensor.RawTensor
 //nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
 func conv2dInputBackwardFloat32(
 	inputGrad, grad, kernel *tensor.RawTensor,
-	n, cIn, h, w, cOut, kH, kW, hOut, wOut, stride, padding int,
+	dims *ConvDims,
 ) {
 	inputGradData := inputGrad.AsFloat32()
 	gradData := grad.AsFloat32()
 	kernelData := kernel.AsFloat32()
+
+	n := dims.N
+	cIn := dims.CIn
+	h := dims.H
+	w := dims.W
+	cOut := dims.COut
+	kH := dims.KH
+	kW := dims.KW
+	hOut := dims.HOut
+	wOut := dims.WOut
+	stride := dims.Stride
+	padding := dims.Padding
 
 	// Initialize to zero
 	for i := range inputGradData {
@@ -147,14 +164,26 @@ func conv2dInputBackwardFloat32(
 
 // conv2dInputBackwardFloat64 computes input gradient for float64.
 //
-//nolint:dupl,gocritic,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
+//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
 func conv2dInputBackwardFloat64(
 	inputGrad, grad, kernel *tensor.RawTensor,
-	N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding int,
+	dims *ConvDims,
 ) {
 	inputGradData := inputGrad.AsFloat64()
 	gradData := grad.AsFloat64()
 	kernelData := kernel.AsFloat64()
+
+	N := dims.N
+	CIn := dims.CIn
+	H := dims.H
+	W := dims.W
+	COut := dims.COut
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
+	stride := dims.Stride
+	padding := dims.Padding
 
 	for i := range inputGradData {
 		inputGradData[i] = 0.0
@@ -213,11 +242,21 @@ func conv2dInputBackwardFloat64(
 //nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dInputBackwardFloat32Stride1NoPad(
 	inputGrad, grad, kernel *tensor.RawTensor,
-	n, cIn, h, w, cOut, kH, kW, hOut, wOut int,
+	dims *ConvDims,
 ) {
 	inputGradData := inputGrad.AsFloat32()
 	gradData := grad.AsFloat32()
 	kernelData := kernel.AsFloat32()
+
+	n := dims.N
+	cIn := dims.CIn
+	h := dims.H
+	w := dims.W
+	cOut := dims.COut
+	kH := dims.KH
+	kW := dims.KW
+	hOut := dims.HOut
+	wOut := dims.WOut
 
 	// Initialize to zero
 	for i := range inputGradData {
@@ -274,14 +313,24 @@ func conv2dInputBackwardFloat32Stride1NoPad(
 // conv2dInputBackwardFloat64Stride1NoPad is optimized for stride=1, padding=0.
 // Compiler can better optimize this with hardcoded stride=1 (loop unrolling, SIMD).
 //
-//nolint:dupl,gocognit,gocritic // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
+//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dInputBackwardFloat64Stride1NoPad(
 	inputGrad, grad, kernel *tensor.RawTensor,
-	N, CIn, H, W, COut, KH, KW, HOut, WOut int,
+	dims *ConvDims,
 ) {
 	inputGradData := inputGrad.AsFloat64()
 	gradData := grad.AsFloat64()
 	kernelData := kernel.AsFloat64()
+
+	N := dims.N
+	CIn := dims.CIn
+	H := dims.H
+	W := dims.W
+	COut := dims.COut
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
 
 	for i := range inputGradData {
 		inputGradData[i] = 0.0
@@ -361,32 +410,37 @@ func (cpu *CPUBackend) Conv2DKernelBackward(input, kernel, grad *tensor.RawTenso
 		panic(fmt.Sprintf("Conv2DKernelBackward: failed to create gradient tensor: %v", err))
 	}
 
+	convDims := &ConvDims{
+		N: N, CIn: CIn, H: H, W: W,
+		COut: COut, KH: KH, KW: KW,
+		HOut: HOut, WOut: WOut,
+		Stride: stride, Padding: padding,
+	}
+
 	// Dispatch by dtype and stride (stride specialization for compiler optimization)
 	switch grad.DType() {
 	case tensor.Float32:
 		if stride == 1 && padding == 0 {
 			conv2dKernelBackwardFloat32Stride1NoPad(
 				kernelGrad, grad, input,
-				N, CIn, H, W, COut, KH, KW, HOut, WOut,
+				convDims,
 			)
 		} else {
 			conv2dKernelBackwardFloat32(
 				kernelGrad, grad, input,
-				N, CIn, H, W, COut, KH, KW, HOut, WOut,
-				stride, padding,
+				convDims,
 			)
 		}
 	case tensor.Float64:
 		if stride == 1 && padding == 0 {
 			conv2dKernelBackwardFloat64Stride1NoPad(
 				kernelGrad, grad, input,
-				N, CIn, H, W, COut, KH, KW, HOut, WOut,
+				convDims,
 			)
 		} else {
 			conv2dKernelBackwardFloat64(
 				kernelGrad, grad, input,
-				N, CIn, H, W, COut, KH, KW, HOut, WOut,
-				stride, padding,
+				convDims,
 			)
 		}
 	default:
@@ -398,14 +452,26 @@ func (cpu *CPUBackend) Conv2DKernelBackward(input, kernel, grad *tensor.RawTenso
 
 // conv2dKernelBackwardFloat32 computes kernel gradient for float32.
 //
-//nolint:dupl,gocritic,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
+//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
 func conv2dKernelBackwardFloat32(
 	kernelGrad, grad, input *tensor.RawTensor,
-	N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding int,
+	dims *ConvDims,
 ) {
 	kernelGradData := kernelGrad.AsFloat32()
 	gradData := grad.AsFloat32()
 	inputData := input.AsFloat32()
+
+	N := dims.N
+	CIn := dims.CIn
+	H := dims.H
+	W := dims.W
+	COut := dims.COut
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
+	stride := dims.Stride
+	padding := dims.Padding
 
 	// Initialize to zero
 	for i := range kernelGradData {
@@ -448,14 +514,26 @@ func conv2dKernelBackwardFloat32(
 
 // conv2dKernelBackwardFloat64 computes kernel gradient for float64.
 //
-//nolint:dupl,gocritic,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
+//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
 func conv2dKernelBackwardFloat64(
 	kernelGrad, grad, input *tensor.RawTensor,
-	N, CIn, H, W, COut, KH, KW, HOut, WOut, stride, padding int,
+	dims *ConvDims,
 ) {
 	kernelGradData := kernelGrad.AsFloat64()
 	gradData := grad.AsFloat64()
 	inputData := input.AsFloat64()
+
+	N := dims.N
+	CIn := dims.CIn
+	H := dims.H
+	W := dims.W
+	COut := dims.COut
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
+	stride := dims.Stride
+	padding := dims.Padding
 
 	for i := range kernelGradData {
 		kernelGradData[i] = 0.0
@@ -493,14 +571,24 @@ func conv2dKernelBackwardFloat64(
 // conv2dKernelBackwardFloat32Stride1NoPad is optimized for stride=1, padding=0.
 // Compiler can better optimize this with hardcoded stride=1 (loop unrolling, SIMD).
 //
-//nolint:dupl,gocritic,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
+//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dKernelBackwardFloat32Stride1NoPad(
 	kernelGrad, grad, input *tensor.RawTensor,
-	N, CIn, H, W, COut, KH, KW, HOut, WOut int,
+	dims *ConvDims,
 ) {
 	kernelGradData := kernelGrad.AsFloat32()
 	gradData := grad.AsFloat32()
 	inputData := input.AsFloat32()
+
+	N := dims.N
+	CIn := dims.CIn
+	H := dims.H
+	W := dims.W
+	COut := dims.COut
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
 
 	// Initialize to zero
 	for i := range kernelGradData {
@@ -542,14 +630,24 @@ func conv2dKernelBackwardFloat32Stride1NoPad(
 // conv2dKernelBackwardFloat64Stride1NoPad is optimized for stride=1, padding=0.
 // Compiler can better optimize this with hardcoded stride=1 (loop unrolling, SIMD).
 //
-//nolint:dupl,gocritic,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
+//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dKernelBackwardFloat64Stride1NoPad(
 	kernelGrad, grad, input *tensor.RawTensor,
-	N, CIn, H, W, COut, KH, KW, HOut, WOut int,
+	dims *ConvDims,
 ) {
 	kernelGradData := kernelGrad.AsFloat64()
 	gradData := grad.AsFloat64()
 	inputData := input.AsFloat64()
+
+	N := dims.N
+	CIn := dims.CIn
+	H := dims.H
+	W := dims.W
+	COut := dims.COut
+	KH := dims.KH
+	KW := dims.KW
+	HOut := dims.HOut
+	WOut := dims.WOut
 
 	for i := range kernelGradData {
 		kernelGradData[i] = 0.0

--- a/internal/backend/cpu/conv2d_test.go
+++ b/internal/backend/cpu/conv2d_test.go
@@ -298,3 +298,141 @@ func TestConv2D_MatchesMockBackend(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkConv2D(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{1, 1, 28, 28}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{6, 1, 5, 5}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2D(input, kernel, 1, 0)
+	}
+}
+
+func BenchmarkConv2D_Batch(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{64, 1, 28, 28}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{32, 1, 3, 3}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2D(input, kernel, 1, 1)
+	}
+}
+
+func BenchmarkConv2D_MultiChannel(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{1, 16, 14, 14}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{32, 16, 3, 3}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2D(input, kernel, 1, 1)
+	}
+}
+
+func BenchmarkConv2D_Stride2(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{1, 8, 32, 32}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{16, 8, 3, 3}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2D(input, kernel, 2, 0)
+	}
+}
+
+func BenchmarkConv2D_Deep(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{8, 64, 14, 14}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{128, 64, 3, 3}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2D(input, kernel, 1, 1)
+	}
+}
+
+func BenchmarkConv2DInputBackward_Batch(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{64, 1, 28, 28}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{32, 1, 3, 3}, tensor.Float32, tensor.CPU)
+	grad, _ := tensor.NewRaw(tensor.Shape{64, 32, 26, 26}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2DInputBackward(input, kernel, grad, 1, 1)
+	}
+}
+
+func BenchmarkConv2DInputBackward_MultiChannel(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{1, 16, 14, 14}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{32, 16, 3, 3}, tensor.Float32, tensor.CPU)
+	grad, _ := tensor.NewRaw(tensor.Shape{1, 32, 12, 12}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2DInputBackward(input, kernel, grad, 1, 1)
+	}
+}
+
+func BenchmarkConv2DInputBackward_Deep(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{8, 64, 14, 14}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{128, 64, 3, 3}, tensor.Float32, tensor.CPU)
+	grad, _ := tensor.NewRaw(tensor.Shape{8, 128, 12, 12}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2DInputBackward(input, kernel, grad, 1, 1)
+	}
+}
+
+func BenchmarkConv2DKernelBackward_Batch(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{64, 1, 28, 28}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{32, 1, 3, 3}, tensor.Float32, tensor.CPU)
+	grad, _ := tensor.NewRaw(tensor.Shape{64, 32, 26, 26}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2DKernelBackward(input, kernel, grad, 1, 1)
+	}
+}
+
+func BenchmarkConv2DKernelBackward_MultiChannel(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{1, 16, 14, 14}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{32, 16, 3, 3}, tensor.Float32, tensor.CPU)
+	grad, _ := tensor.NewRaw(tensor.Shape{1, 32, 12, 12}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2DKernelBackward(input, kernel, grad, 1, 1)
+	}
+}
+
+func BenchmarkConv2DKernelBackward_Deep(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{8, 64, 14, 14}, tensor.Float32, tensor.CPU)
+	kernel, _ := tensor.NewRaw(tensor.Shape{128, 64, 3, 3}, tensor.Float32, tensor.CPU)
+	grad, _ := tensor.NewRaw(tensor.Shape{8, 128, 12, 12}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.Conv2DKernelBackward(input, kernel, grad, 1, 1)
+	}
+}

--- a/internal/backend/cpu/conv2d_test.go
+++ b/internal/backend/cpu/conv2d_test.go
@@ -302,8 +302,8 @@ func TestConv2D_MatchesMockBackend(t *testing.T) {
 func BenchmarkConv2D(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{1, 1, 28, 28}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{6, 1, 5, 5}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{1, 1, 28, 28}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{6, 1, 5, 5}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -314,8 +314,8 @@ func BenchmarkConv2D(b *testing.B) {
 func BenchmarkConv2D_Batch(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{64, 1, 28, 28}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{32, 1, 3, 3}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{64, 1, 28, 28}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{32, 1, 3, 3}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -326,8 +326,8 @@ func BenchmarkConv2D_Batch(b *testing.B) {
 func BenchmarkConv2D_MultiChannel(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{1, 16, 14, 14}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{32, 16, 3, 3}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{1, 16, 14, 14}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{32, 16, 3, 3}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -338,8 +338,8 @@ func BenchmarkConv2D_MultiChannel(b *testing.B) {
 func BenchmarkConv2D_Stride2(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{1, 8, 32, 32}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{16, 8, 3, 3}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{1, 8, 32, 32}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{16, 8, 3, 3}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -350,8 +350,8 @@ func BenchmarkConv2D_Stride2(b *testing.B) {
 func BenchmarkConv2D_Deep(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{8, 64, 14, 14}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{128, 64, 3, 3}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{8, 64, 14, 14}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{128, 64, 3, 3}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -362,9 +362,9 @@ func BenchmarkConv2D_Deep(b *testing.B) {
 func BenchmarkConv2DInputBackward_Batch(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{64, 1, 28, 28}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{32, 1, 3, 3}, tensor.Float32, tensor.CPU)
-	grad, _ := tensor.NewRaw(tensor.Shape{64, 32, 26, 26}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{64, 1, 28, 28}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{32, 1, 3, 3}, backend).Raw()
+	grad := tensor.Randn[float32](tensor.Shape{64, 32, 26, 26}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -375,9 +375,9 @@ func BenchmarkConv2DInputBackward_Batch(b *testing.B) {
 func BenchmarkConv2DInputBackward_MultiChannel(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{1, 16, 14, 14}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{32, 16, 3, 3}, tensor.Float32, tensor.CPU)
-	grad, _ := tensor.NewRaw(tensor.Shape{1, 32, 12, 12}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{1, 16, 14, 14}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{32, 16, 3, 3}, backend).Raw()
+	grad := tensor.Randn[float32](tensor.Shape{1, 32, 12, 12}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -388,9 +388,9 @@ func BenchmarkConv2DInputBackward_MultiChannel(b *testing.B) {
 func BenchmarkConv2DInputBackward_Deep(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{8, 64, 14, 14}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{128, 64, 3, 3}, tensor.Float32, tensor.CPU)
-	grad, _ := tensor.NewRaw(tensor.Shape{8, 128, 12, 12}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{8, 64, 14, 14}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{128, 64, 3, 3}, backend).Raw()
+	grad := tensor.Randn[float32](tensor.Shape{8, 128, 12, 12}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -401,9 +401,9 @@ func BenchmarkConv2DInputBackward_Deep(b *testing.B) {
 func BenchmarkConv2DKernelBackward_Batch(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{64, 1, 28, 28}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{32, 1, 3, 3}, tensor.Float32, tensor.CPU)
-	grad, _ := tensor.NewRaw(tensor.Shape{64, 32, 26, 26}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{64, 1, 28, 28}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{32, 1, 3, 3}, backend).Raw()
+	grad := tensor.Randn[float32](tensor.Shape{64, 32, 26, 26}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -414,9 +414,9 @@ func BenchmarkConv2DKernelBackward_Batch(b *testing.B) {
 func BenchmarkConv2DKernelBackward_MultiChannel(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{1, 16, 14, 14}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{32, 16, 3, 3}, tensor.Float32, tensor.CPU)
-	grad, _ := tensor.NewRaw(tensor.Shape{1, 32, 12, 12}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{1, 16, 14, 14}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{32, 16, 3, 3}, backend).Raw()
+	grad := tensor.Randn[float32](tensor.Shape{1, 32, 12, 12}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -427,9 +427,9 @@ func BenchmarkConv2DKernelBackward_MultiChannel(b *testing.B) {
 func BenchmarkConv2DKernelBackward_Deep(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{8, 64, 14, 14}, tensor.Float32, tensor.CPU)
-	kernel, _ := tensor.NewRaw(tensor.Shape{128, 64, 3, 3}, tensor.Float32, tensor.CPU)
-	grad, _ := tensor.NewRaw(tensor.Shape{8, 128, 12, 12}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{8, 64, 14, 14}, backend).Raw()
+	kernel := tensor.Randn[float32](tensor.Shape{128, 64, 3, 3}, backend).Raw()
+	grad := tensor.Randn[float32](tensor.Shape{8, 128, 12, 12}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {

--- a/internal/backend/cpu/maxpool2d.go
+++ b/internal/backend/cpu/maxpool2d.go
@@ -6,6 +6,14 @@ import (
 	"github.com/born-ml/born/internal/tensor"
 )
 
+// PoolDims groups pooling dimension parameters.
+type PoolDims struct {
+	N, C, H, W      int // Input dimensions
+	KH, KW          int // Kernel dimensions
+	HOut, WOut      int // Output dimensions
+	Stride, Padding int // Pooling parameters
+}
+
 // MaxPool2D performs 2D max pooling.
 //
 // Max pooling reduces spatial dimensions by taking the maximum value
@@ -71,12 +79,19 @@ func (cpu *CPUBackend) MaxPool2D(input *tensor.RawTensor, kernelSize, stride int
 		panic(fmt.Sprintf("maxpool2d: failed to create output: %v", err))
 	}
 
+	poolDims := &PoolDims{
+		N: N, C: C, H: H, W: W,
+		KH: kernelSize, KW: kernelSize,
+		HOut: HOut, WOut: WOut,
+		Stride: stride,
+	}
+
 	// Dispatch to type-specific implementation
 	switch input.DType() {
 	case tensor.Float32:
-		maxpool2dFloat32(output, input, N, C, H, W, HOut, WOut, kernelSize, stride)
+		maxpool2dFloat32(output, input, poolDims)
 	case tensor.Float64:
-		maxpool2dFloat64(output, input, N, C, H, W, HOut, WOut, kernelSize, stride)
+		maxpool2dFloat64(output, input, poolDims)
 	default:
 		panic(fmt.Sprintf("maxpool2d: unsupported dtype %v", input.DType()))
 	}
@@ -85,9 +100,18 @@ func (cpu *CPUBackend) MaxPool2D(input *tensor.RawTensor, kernelSize, stride int
 }
 
 // maxpool2dFloat32 performs max pooling for float32 tensors.
-func maxpool2dFloat32(output, input *tensor.RawTensor, N, C, H, W, HOut, WOut, kernelSize, stride int) {
+func maxpool2dFloat32(output, input *tensor.RawTensor, dims *PoolDims) {
 	inputData := input.AsFloat32()
 	outputData := output.AsFloat32()
+
+	N := dims.N
+	C := dims.C
+	H := dims.H
+	W := dims.W
+	HOut := dims.HOut
+	WOut := dims.WOut
+	kernelSize := dims.KH
+	stride := dims.Stride
 
 	// For each batch
 	for n := 0; n < N; n++ {
@@ -135,9 +159,18 @@ func maxpool2dFloat32(output, input *tensor.RawTensor, N, C, H, W, HOut, WOut, k
 }
 
 // maxpool2dFloat64 performs max pooling for float64 tensors.
-func maxpool2dFloat64(output, input *tensor.RawTensor, N, C, H, W, HOut, WOut, kernelSize, stride int) {
+func maxpool2dFloat64(output, input *tensor.RawTensor, dims *PoolDims) {
 	inputData := input.AsFloat64()
 	outputData := output.AsFloat64()
+
+	N := dims.N
+	C := dims.C
+	H := dims.H
+	W := dims.W
+	HOut := dims.HOut
+	WOut := dims.WOut
+	kernelSize := dims.KH
+	stride := dims.Stride
 
 	// For each batch
 	for n := 0; n < N; n++ {

--- a/internal/backend/cpu/maxpool2d_backward.go
+++ b/internal/backend/cpu/maxpool2d_backward.go
@@ -44,21 +44,26 @@ func (cpu *CPUBackend) MaxPool2DBackward(input, grad *tensor.RawTensor, maxIndic
 		panic(fmt.Sprintf("MaxPool2DBackward: maxIndices length %d != expected %d", len(maxIndices), expectedLen))
 	}
 
+	poolDims := &PoolDims{
+		N: N, C: C, H: H, W: W,
+		KH: kernelSize, KW: kernelSize,
+		HOut: HOut, WOut: WOut,
+		Stride: stride,
+	}
+
 	// Dispatch by dtype
 	switch grad.DType() {
 	case tensor.Float32:
 		maxPool2DBackwardFloat32(
 			inputGrad, grad,
 			maxIndices,
-			N, C, H, W, HOut, WOut,
-			kernelSize, stride,
+			poolDims,
 		)
 	case tensor.Float64:
 		maxPool2DBackwardFloat64(
 			inputGrad, grad,
 			maxIndices,
-			N, C, H, W, HOut, WOut,
-			kernelSize, stride,
+			poolDims,
 		)
 	default:
 		panic("MaxPool2DBackward: unsupported dtype")
@@ -68,15 +73,18 @@ func (cpu *CPUBackend) MaxPool2DBackward(input, grad *tensor.RawTensor, maxIndic
 }
 
 // maxPool2DBackwardFloat32 routes gradients to max positions for float32.
-//
-//nolint:gocritic // Short var names N,C for readability; unused params for API consistency
 func maxPool2DBackwardFloat32(
 	inputGrad, grad *tensor.RawTensor,
 	maxIndices []int,
-	N, C, _, _, HOut, WOut, _, _ int,
+	dims *PoolDims,
 ) {
 	inputGradData := inputGrad.AsFloat32()
 	gradData := grad.AsFloat32()
+
+	N := dims.N
+	C := dims.C
+	HOut := dims.HOut
+	WOut := dims.WOut
 
 	// Initialize to zero
 	for i := range inputGradData {
@@ -107,15 +115,18 @@ func maxPool2DBackwardFloat32(
 }
 
 // maxPool2DBackwardFloat64 routes gradients to max positions for float64.
-//
-//nolint:gocritic // Short var names N,C for readability; unused params for API consistency
 func maxPool2DBackwardFloat64(
 	inputGrad, grad *tensor.RawTensor,
 	maxIndices []int,
-	N, C, _, _, HOut, WOut, _, _ int,
+	dims *PoolDims,
 ) {
 	inputGradData := inputGrad.AsFloat64()
 	gradData := grad.AsFloat64()
+
+	N := dims.N
+	C := dims.C
+	HOut := dims.HOut
+	WOut := dims.WOut
 
 	for i := range inputGradData {
 		inputGradData[i] = 0.0

--- a/internal/backend/cpu/maxpool2d_test.go
+++ b/internal/backend/cpu/maxpool2d_test.go
@@ -218,3 +218,58 @@ func TestMaxPool2D_Float64(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkMaxPool2D_Forward(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{1, 1, 28, 28}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.MaxPool2D(input, 2, 2)
+	}
+}
+
+func BenchmarkMaxPool2D_Forward_Batch(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{64, 1, 28, 28}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.MaxPool2D(input, 2, 2)
+	}
+}
+
+func BenchmarkMaxPool2D_Forward_MultiChannel(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{1, 16, 14, 14}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.MaxPool2D(input, 3, 1)
+	}
+}
+
+func BenchmarkMaxPool2D_Forward_Stride2(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{1, 8, 32, 32}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.MaxPool2D(input, 2, 2)
+	}
+}
+
+func BenchmarkMaxPool2D_Forward_Deep(b *testing.B) {
+	backend := New()
+
+	input, _ := tensor.NewRaw(tensor.Shape{8, 64, 14, 14}, tensor.Float32, tensor.CPU)
+
+	b.ResetTimer()
+	for b.Loop() {
+		backend.MaxPool2D(input, 3, 1)
+	}
+}

--- a/internal/backend/cpu/maxpool2d_test.go
+++ b/internal/backend/cpu/maxpool2d_test.go
@@ -222,7 +222,7 @@ func TestMaxPool2D_Float64(t *testing.T) {
 func BenchmarkMaxPool2D_Forward(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{1, 1, 28, 28}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{1, 1, 28, 28}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -233,7 +233,7 @@ func BenchmarkMaxPool2D_Forward(b *testing.B) {
 func BenchmarkMaxPool2D_Forward_Batch(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{64, 1, 28, 28}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{64, 1, 28, 28}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -244,7 +244,7 @@ func BenchmarkMaxPool2D_Forward_Batch(b *testing.B) {
 func BenchmarkMaxPool2D_Forward_MultiChannel(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{1, 16, 14, 14}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{1, 16, 14, 14}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -255,7 +255,7 @@ func BenchmarkMaxPool2D_Forward_MultiChannel(b *testing.B) {
 func BenchmarkMaxPool2D_Forward_Stride2(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{1, 8, 32, 32}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{1, 8, 32, 32}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -266,7 +266,7 @@ func BenchmarkMaxPool2D_Forward_Stride2(b *testing.B) {
 func BenchmarkMaxPool2D_Forward_Deep(b *testing.B) {
 	backend := New()
 
-	input, _ := tensor.NewRaw(tensor.Shape{8, 64, 14, 14}, tensor.Float32, tensor.CPU)
+	input := tensor.Randn[float32](tensor.Shape{8, 64, 14, 14}, backend).Raw()
 
 	b.ResetTimer()
 	for b.Loop() {


### PR DESCRIPTION
Addresses #16 

Thanks to the well-documented issue, this was fairly straightforward.  The issue mentions that `internal/autodiff/ops/conv2d.go` should be updated, but I don't see a function signature consistent with the rest of the changes.

-------
I added benchmarks to:
- `internal/autodiff/ops/maxpool2d_test.go`
- `internal/backend/cpu/conv2d_test.go`
- `internal/backend/cpu/maxpool2d_test.go`

On my machine these were the results:
```bash
% go test -bench=. -benchmem ./internal/backend/cpu/... ./internal/autodiff/ops/...
goos: darwin
goarch: arm64
pkg: github.com/born-ml/born/internal/backend/cpu
cpu: Apple M1
BenchmarkConv2D-8                                  13921             84321 ns/op           94416 B/op          7 allocs/op
BenchmarkConv2D_Batch-8                               76          14105481 ns/op        14655780 B/op          7 allocs/op
BenchmarkConv2D_MultiChannel-8                      1192            988445 ns/op          169424 B/op          7 allocs/op
BenchmarkConv2D_Stride2-8                           4494            256082 ns/op           98512 B/op          7 allocs/op
BenchmarkConv2D_Deep-8                                 8         140531088 ns/op         5218524 B/op          7 allocs/op
BenchmarkConv2DInputBackward_Batch-8                  52          22862217 ns/op          205008 B/op          5 allocs/op
BenchmarkConv2DInputBackward_MultiChannel-8         1032           1144036 ns/op           13776 B/op          5 allocs/op
BenchmarkConv2DInputBackward_Deep-8                    7         143954077 ns/op          401616 B/op          5 allocs/op
BenchmarkConv2DKernelBackward_Batch-8                 46          25402187 ns/op            1360 B/op          5 allocs/op
BenchmarkConv2DKernelBackward_MultiChannel-8         834           1425880 ns/op           18640 B/op          5 allocs/op
BenchmarkConv2DKernelBackward_Deep-8                   6         183532090 ns/op          295120 B/op          5 allocs/op
BenchmarkMaxPool2D_Forward-8                      453834              2417 ns/op            1104 B/op          5 allocs/op
BenchmarkMaxPool2D_Forward_Batch-8                  4976            228700 ns/op           57552 B/op          5 allocs/op
BenchmarkMaxPool2D_Forward_MultiChannel-8          23517             50821 ns/op            9680 B/op          5 allocs/op
BenchmarkMaxPool2D_Forward_Stride2-8               34431             34693 ns/op            8400 B/op          5 allocs/op
BenchmarkMaxPool2D_Forward_Deep-8                    658           1808138 ns/op          295120 B/op          5 allocs/op
PASS
ok      github.com/born-ml/born/internal/backend/cpu    18.796s
goos: darwin
goarch: arm64
pkg: github.com/born-ml/born/internal/autodiff/ops
cpu: Apple M1
BenchmarkMaxPool2D_Backward_Batch-8                49996             22565 ns/op          205008 B/op          5 allocs/op
BenchmarkMaxPool2D_Backward_MultiChannel-8        203715              5750 ns/op           13776 B/op          5 allocs/op
BenchmarkMaxPool2D_Backward_Deep-8                  6284            183987 ns/op          401619 B/op          5 allocs/op
PASS
ok      github.com/born-ml/born/internal/autodiff/ops   3.742s
```


If I run the same benchmarks without the new changes (`git checkout main && git cherry-pick 46ba911 2eed4f0`) these are the results on my machine:
```bash
% go test -bench=. -benchmem ./internal/backend/cpu/... ./internal/autodiff/ops/...
goos: darwin
goarch: arm64
pkg: github.com/born-ml/born/internal/backend/cpu
cpu: Apple M1
BenchmarkConv2D-8                                  14012             84670 ns/op           94416 B/op          7 allocs/op
BenchmarkConv2D_Batch-8                               79          14164366 ns/op        14655771 B/op          7 allocs/op
BenchmarkConv2D_MultiChannel-8                      1198            988730 ns/op          169424 B/op          7 allocs/op
BenchmarkConv2D_Stride2-8                           4536            255876 ns/op           98512 B/op          7 allocs/op
BenchmarkConv2D_Deep-8                                 8         140529526 ns/op         5218536 B/op          7 allocs/op
BenchmarkConv2DInputBackward_Batch-8                  45          25566617 ns/op          205010 B/op          5 allocs/op
BenchmarkConv2DInputBackward_MultiChannel-8          908           1311453 ns/op           13776 B/op          5 allocs/op
BenchmarkConv2DInputBackward_Deep-8                    7         165482899 ns/op          401629 B/op          5 allocs/op
BenchmarkConv2DKernelBackward_Batch-8                 45          25494102 ns/op            1360 B/op          5 allocs/op
BenchmarkConv2DKernelBackward_MultiChannel-8         835           1430829 ns/op           18640 B/op          5 allocs/op
BenchmarkConv2DKernelBackward_Deep-8                   6         184204444 ns/op          295120 B/op          5 allocs/op
BenchmarkMaxPool2D_Forward-8                      592278              1916 ns/op            1104 B/op          5 allocs/op
BenchmarkMaxPool2D_Forward_Batch-8                  4998            227607 ns/op           57552 B/op          5 allocs/op
BenchmarkMaxPool2D_Forward_MultiChannel-8          24733             48369 ns/op            9680 B/op          5 allocs/op
BenchmarkMaxPool2D_Forward_Stride2-8               36374             32915 ns/op            8400 B/op          5 allocs/op
BenchmarkMaxPool2D_Forward_Deep-8                    661           1799755 ns/op          295121 B/op          5 allocs/op
PASS
ok      github.com/born-ml/born/internal/backend/cpu    18.930s
goos: darwin
goarch: arm64
pkg: github.com/born-ml/born/internal/autodiff/ops
cpu: Apple M1
BenchmarkMaxPool2D_Backward_Batch-8                49416             22668 ns/op          205009 B/op          5 allocs/op
BenchmarkMaxPool2D_Backward_MultiChannel-8        205414              5659 ns/op           13776 B/op          5 allocs/op
BenchmarkMaxPool2D_Backward_Deep-8                  6216            182006 ns/op          401619 B/op          5 allocs/op
PASS
ok      github.com/born-ml/born/internal/autodiff/ops   3.689s
```