### PR TITLE
fix(ci): add gate job for branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,3 +173,23 @@ jobs:
 
     - name: Run benchmarks
       run: go test -bench=. -benchmem -run=^$ ./internal/tensor/...
+
+  # Gate job for branch protection — single required check
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [unit-tests, lint, formatting, build-examples, build-tools, benchmarks]
+    steps:
+    - name: Check results
+      run: |
+        if [[ "${{ needs.unit-tests.result }}" == "failure" || \
+              "${{ needs.lint.result }}" == "failure" || \
+              "${{ needs.formatting.result }}" == "failure" || \
+              "${{ needs.build-examples.result }}" == "failure" || \
+              "${{ needs.build-tools.result }}" == "failure" || \
+              "${{ needs.benchmarks.result }}" == "failure" ]]; then
+          echo "One or more required jobs failed"
+          exit 1
+        fi
+        echo "All checks passed ✓"


### PR DESCRIPTION
## Summary
- Branch protection requires a check named `test`, but no CI job had that name
- Added a gate job that depends on all other jobs and reports aggregate status
- This unblocks PR merging (including PR #49)

## Test plan
- CI runs on this PR and the new `test` job appears green
- After merge, PR #49 can be merged normally