### PR TITLE
fix(cpu): prevent inplace mutation when operands alias

### DIFF
--- a/internal/backend/cpu/backend.go
+++ b/internal/backend/cpu/backend.go
@@ -44,8 +44,8 @@ func (cpu *CPUBackend) Add(a, b *tensor.RawTensor) *tensor.RawTensor {
 	// Check for inplace optimization
 	if !needsBroadcast && a.Shape().Equal(b.Shape()) {
 		// Fast path: same shape, check if we can do inplace
-		if a.IsUnique() {
-			// Inplace add into a
+		if a.IsUnique() && a != b {
+			// Inplace add into a (safe: operands don't alias)
 			addInplace(a, b)
 			return a
 		}
@@ -72,7 +72,7 @@ func (cpu *CPUBackend) Sub(a, b *tensor.RawTensor) *tensor.RawTensor {
 	}
 
 	if !needsBroadcast && a.Shape().Equal(b.Shape()) {
-		if a.IsUnique() {
+		if a.IsUnique() && a != b {
 			subInplace(a, b)
 			return a
 		}
@@ -97,7 +97,7 @@ func (cpu *CPUBackend) Mul(a, b *tensor.RawTensor) *tensor.RawTensor {
 	}
 
 	if !needsBroadcast && a.Shape().Equal(b.Shape()) {
-		if a.IsUnique() {
+		if a.IsUnique() && a != b {
 			mulInplace(a, b)
 			return a
 		}
@@ -122,7 +122,7 @@ func (cpu *CPUBackend) Div(a, b *tensor.RawTensor) *tensor.RawTensor {
 	}
 
 	if !needsBroadcast && a.Shape().Equal(b.Shape()) {
-		if a.IsUnique() {
+		if a.IsUnique() && a != b {
 			divInplace(a, b)
 			return a
 		}

--- a/internal/backend/cpu/backend_test.go
+++ b/internal/backend/cpu/backend_test.go
@@ -1558,3 +1558,40 @@ func TestCPUBackend_Float32VectorizedOps(t *testing.T) {
 		}
 	})
 }
+
+// TestSelfOperandAliasing verifies that binary ops with the same tensor as both
+// operands (e.g. Mul(x, x)) do not mutate the input.
+// Regression test for https://github.com/born-ml/born/issues/45
+func TestSelfOperandAliasing(t *testing.T) {
+	backend := newTestBackend()
+
+	tests := []struct {
+		name string
+		op   func(a, b *tensor.RawTensor) *tensor.RawTensor
+		want []float32
+	}{
+		{"Mul(x,x)", backend.Mul, []float32{2.25, 0.25, 0.25, 2.25}},
+		{"Add(x,x)", backend.Add, []float32{-3, -1, 1, 3}},
+		{"Sub(x,x)", backend.Sub, []float32{0, 0, 0, 0}},
+		{"Div(x,x)", backend.Div, []float32{1, 1, 1, 1}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			x, _ := tensor.FromSlice([]float32{-1.5, -0.5, 0.5, 1.5}, tensor.Shape{4}, backend)
+			original := append([]float32(nil), x.Raw().AsFloat32()...)
+
+			result := tc.op(x.Raw(), x.Raw())
+
+			// Result must be correct
+			if !float32SliceEqual(result.AsFloat32(), tc.want) {
+				t.Errorf("result: got %v, want %v", result.AsFloat32(), tc.want)
+			}
+
+			// Input must NOT be mutated
+			if !float32SliceEqual(x.Raw().AsFloat32(), original) {
+				t.Errorf("input mutated: got %v, was %v", x.Raw().AsFloat32(), original)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add aliasing guard (`a != b`) to inplace optimization in Add, Sub, Mul, Div
- Without this, `Mul(x, x)` silently corrupts the input tensor
- Also affects LayerNorm when used through cpu backend without autodiff wrapper

## Details
The CPU backend's inplace optimization (`IsUnique()`) mutates the left operand when it has a unique reference. When both operands point to the same tensor (e.g. `Mul(x, x)`), this corrupts the input before the operation completes.

Fix: `if a.IsUnique() && a != b` — skip inplace path when operands alias.

## Test plan
- [x] `TestSelfOperandAliasing` — verifies all 4 ops (Add, Sub, Mul, Div) with same-tensor operands
- [x] Input is not mutated after operation
- [x] Result is mathematically correct
- [x] All existing tests pass
- [x] Lint clean

Fixes #45
Reported by @gmohmad