### PR TITLE
refactor: conv2d/maxpool2d helper extraction + shared dims + docs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Third external contributor [@gmohmad](https://github.com/gmohmad) with 4 PRs! Pl
 
 **Refactored**:
 - `ConvDims` and `PoolDims` parameter structs to reduce argument counts in conv2d/maxpool2d ([#46](https://github.com/born-ml/born/pull/46) by @bennibbelink)
+- Moved `ConvDims`/`PoolDims` to `internal/tensor/` shared package, eliminating autodiff→cpu cross-dependency (fixes [#48](https://github.com/born-ml/born/issues/48))
+- Extracted 14 helper functions from conv2d/maxpool2d inner loops (fixes [#17](https://github.com/born-ml/born/issues/17)) — compiler-inlined, Conv2D batch path ~28% faster
 
 **Added** (PR #56 by @gmohmad):
 - ONNX comparison operators: Greater, GreaterOrEqual, Less, LessOrEqual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🎉 Community Contributions — @gmohmad & @bennibbelink
+
+Third external contributor [@gmohmad](https://github.com/gmohmad) with 4 PRs! Plus continued work from [@bennibbelink](https://github.com/bennibbelink).
+
+**Added**:
+- ONNX `LayerNormalization` operator with new `normalization_ops.go` category ([#47](https://github.com/born-ml/born/pull/47) by @gmohmad)
+- `BroadcastShapesMatMul` — NumPy-style broadcasting for batched matrix multiplication ([#49](https://github.com/born-ml/born/pull/49) by @gmohmad)
+- `BatchMatMul` now supports 2D×3D, singleton batch dims, multi-dim broadcasting
+- ONNX `MatMul` auto-delegates to `BatchMatMul` for >2D inputs
+- `tensor.BroadcastShapesMatMul` public API
+- ONNX `AttributeProto` tensor attribute (field 5) parsing ([#53](https://github.com/born-ml/born/pull/53) by @gmohmad)
+
+**Fixed**:
+- `Squeeze` scalar handling: returns `Shape{}` (scalar) instead of `Shape{1}` (1D) ([#50](https://github.com/born-ml/born/pull/50) by @gmohmad)
+- ONNX `AttributeProto` parser: correct protobuf field numbers, non-packed encoding support ([#53](https://github.com/born-ml/born/pull/53) by @gmohmad)
+- CPU backend: prevent inplace mutation when operands alias — `Mul(x,x)` no longer corrupts input ([#55](https://github.com/born-ml/born/pull/55), fixes [#45](https://github.com/born-ml/born/issues/45), reported by @gmohmad)
+- CI: added `test` gate job for branch protection required check ([#52](https://github.com/born-ml/born/pull/52))
+
+**Refactored**:
+- `ConvDims` and `PoolDims` parameter structs to reduce argument counts in conv2d/maxpool2d ([#46](https://github.com/born-ml/born/pull/46) by @bennibbelink)
+
+**Added** (PR #56 by @gmohmad):
+- ONNX comparison operators: Greater, GreaterOrEqual, Less, LessOrEqual
+- ONNX logical operators: Not, And, Or, Xor (new `logical_ops.go`)
+- ONNX Erf operator
+- Broadcasting for boolean ops (Or, And) and all comparison ops in CPU backend
+
+**Fixed** (PR #56 by @gmohmad):
+- Updated `onnx/onnx.go` doc comment to match all registered operators (fixes [#43](https://github.com/born-ml/born/issues/43))
+
+**ONNX operators**: 39 → 49
+
+---
+
 ## [0.7.15] - 2026-04-07
 
 ### 🎉 Community Contribution — Erf Operator

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ prediction := model.Predict(image)
 - **Text Generation** - Streaming API, stop sequences
 
 ### Model Import & Export
-- **ONNX Import** - Load PyTorch/TensorFlow models via `.onnx` (30+ operators)
+- **ONNX Import** - Load PyTorch/TensorFlow models via `.onnx` (49 operators)
 - **GGUF Import** - llama.cpp format with K-quant dequantization (Q4_K, Q5_K, Q6_K, Q8_0)
 - **Native Format** - `.born` format with `nn.Save()` / `nn.Load()`
 - **Checkpoints** - Resume training with optimizer state preservation
@@ -375,7 +375,7 @@ func (t *Tensor[float32, B]) MatMul(other *Tensor[float32, B]) *Tensor[float32, 
 - Tokenizers (TikToken, BPE), text generation with streaming
 
 **Model Import & Export**
-- ONNX import (30+ operators)
+- ONNX import (49 operators)
 - GGUF loading (LLaMA, Mistral, DeepSeek)
 - Native `.born` format, SafeTensors export
 

--- a/internal/autodiff/ops/maxpool2d.go
+++ b/internal/autodiff/ops/maxpool2d.go
@@ -1,7 +1,6 @@
 package ops
 
 import (
-	"github.com/born-ml/born/internal/backend/cpu"
 	"github.com/born-ml/born/internal/tensor"
 )
 
@@ -62,7 +61,7 @@ func computeMaxIndices(input, output *tensor.RawTensor, kernelSize, stride int) 
 	numOutputs := N * C * HOut * WOut
 	maxIndices := make([]int, numOutputs)
 
-	poolDims := &cpu.PoolDims{
+	poolDims := &tensor.PoolDims{
 		N: N, C: C, H: H, W: W,
 		KH: kernelSize, KW: kernelSize,
 		HOut: HOut, WOut: WOut,
@@ -83,7 +82,7 @@ func computeMaxIndices(input, output *tensor.RawTensor, kernelSize, stride int) 
 }
 
 // computeMaxIndicesFloat32 finds max positions for float32 tensors.
-func computeMaxIndicesFloat32(maxIndices []int, input *tensor.RawTensor, dims *cpu.PoolDims) {
+func computeMaxIndicesFloat32(maxIndices []int, input *tensor.RawTensor, dims *tensor.PoolDims) {
 	inputData := input.AsFloat32()
 
 	N := dims.N
@@ -131,7 +130,7 @@ func computeMaxIndicesFloat32(maxIndices []int, input *tensor.RawTensor, dims *c
 }
 
 // computeMaxIndicesFloat64 finds max positions for float64 tensors.
-func computeMaxIndicesFloat64(maxIndices []int, input *tensor.RawTensor, dims *cpu.PoolDims) {
+func computeMaxIndicesFloat64(maxIndices []int, input *tensor.RawTensor, dims *tensor.PoolDims) {
 	inputData := input.AsFloat64()
 
 	N := dims.N

--- a/internal/backend/cpu/conv2d.go
+++ b/internal/backend/cpu/conv2d.go
@@ -137,32 +137,14 @@ func conv2dFloat32Stride1NoPad(output, input, kernel *tensor.RawTensor, dims *Co
 	colBuf := make([]float32, colHeight*colWidth)
 
 	im2colFloat32Stride1NoPad(colBuf, inputData, dims)
-	// Step 2: Matrix multiplication
-	for i := 0; i < COut; i++ {
-		for j := 0; j < colHeight; j++ {
-			sum := float32(0.0)
-			for k := 0; k < colWidth; k++ {
-				sum += kernelData[i*colWidth+k] * colBuf[j*colWidth+k]
-			}
-			outputData[i*colHeight+j] = sum
-		}
-	}
 
-	// Step 3: Rearrange from [C_out, N*H_out*W_out] to [N, C_out, H_out, W_out]
+	// Step 2: Matrix multiplication via helper (inlined by compiler).
+	matMulColBufFloat32(outputData, kernelData, colBuf, COut, colHeight, colWidth)
+
+	// Step 3: Rearrange from [C_out, N*H_out*W_out] to [N, C_out, H_out, W_out].
 	tempBuf := make([]float32, len(outputData))
 	copy(tempBuf, outputData)
-
-	for n := 0; n < N; n++ {
-		for c := 0; c < COut; c++ {
-			for h := 0; h < HOut; h++ {
-				for w := 0; w < WOut; w++ {
-					srcIdx := c*colHeight + n*HOut*WOut + h*WOut + w
-					dstIdx := n*COut*HOut*WOut + c*HOut*WOut + h*WOut + w
-					outputData[dstIdx] = tempBuf[srcIdx]
-				}
-			}
-		}
-	}
+	rearrangeOutputFloat32(outputData, tempBuf, N, COut, HOut, WOut, colHeight)
 }
 
 // conv2dFloat32General handles arbitrary stride and padding.
@@ -187,49 +169,16 @@ func conv2dFloat32General(output, input, kernel *tensor.RawTensor, dims *ConvDim
 
 	im2colFloat32(colBuf, inputData, dims)
 
-	// Step 2: Reshape kernel
-	// kernelData is already in [C_out, C_in * K_h * K_w] layout (row-major)
+	// Step 2: Reshape kernel — already in [C_out, C_in*K_h*K_w] layout (row-major).
 
-	// Step 3: Matrix multiplication
-	// kernel: [C_out, C_in * K_h * K_w]
-	// colBuf: [C_in * K_h * K_w, N * H_out * W_out] (transposed view)
-	// result: [C_out, N * H_out * W_out]
-	//
-	// We want: result[i, j] = sum_k kernel[i, k] * colBuf[j, k]
-	// But colBuf is in row-major as [N*H_out*W_out, C*K_h*K_w]
-	// So we compute: result[i, j] = sum_k kernel[i, k] * colBuf[j*colWidth + k]
+	// Step 3: Matrix multiplication via helper (inlined by compiler).
+	// kernel: [C_out, C_in*K_h*K_w] @ colBuf^T -> [C_out, N*H_out*W_out]
+	matMulColBufFloat32(outputData, kernelData, colBuf, COut, colHeight, colWidth)
 
-	for i := 0; i < COut; i++ {
-		for j := 0; j < colHeight; j++ {
-			sum := float32(0.0)
-			for k := 0; k < colWidth; k++ {
-				sum += kernelData[i*colWidth+k] * colBuf[j*colWidth+k]
-			}
-			// Temporary storage in row-major: [C_out, N*H_out*W_out]
-			// We'll rearrange this into [N, C_out, H_out, W_out] next
-			outputData[i*colHeight+j] = sum
-		}
-	}
-
-	// Step 4: Rearrange from [C_out, N*H_out*W_out] to [N, C_out, H_out, W_out]
-	// Current layout: output[c, n*H_out*W_out + h*W_out + w]
-	// Desired layout: output[n, c, h, w] = output[n*C_out*H_out*W_out + c*H_out*W_out + h*W_out + w]
+	// Step 4: Rearrange from [C_out, N*H_out*W_out] to [N, C_out, H_out, W_out].
 	tempBuf := make([]float32, len(outputData))
 	copy(tempBuf, outputData)
-
-	for n := 0; n < N; n++ {
-		for c := 0; c < COut; c++ {
-			for h := 0; h < HOut; h++ {
-				for w := 0; w < WOut; w++ {
-					// Source index: [c, n*H_out*W_out + h*W_out + w]
-					srcIdx := c*colHeight + n*HOut*WOut + h*WOut + w
-					// Dest index: [n, c, h, w]
-					dstIdx := n*COut*HOut*WOut + c*HOut*WOut + h*WOut + w
-					outputData[dstIdx] = tempBuf[srcIdx]
-				}
-			}
-		}
-	}
+	rearrangeOutputFloat32(outputData, tempBuf, N, COut, HOut, WOut, colHeight)
 }
 
 // im2colFloat32Stride1NoPad is optimized for stride=1, padding=0.
@@ -384,31 +333,14 @@ func conv2dFloat64Stride1NoPad(output, input, kernel *tensor.RawTensor, dims *Co
 	colHeight := N * HOut * WOut
 	colBuf := make([]float64, colHeight*colWidth)
 	im2colFloat64Stride1NoPad(colBuf, inputData, dims)
-	// MatMul
-	for i := 0; i < COut; i++ {
-		for j := 0; j < colHeight; j++ {
-			sum := float64(0.0)
-			for k := 0; k < colWidth; k++ {
-				sum += kernelData[i*colWidth+k] * colBuf[j*colWidth+k]
-			}
-			outputData[i*colHeight+j] = sum
-		}
-	}
 
-	// Rearrange
+	// MatMul via helper (inlined by compiler).
+	matMulColBufFloat64(outputData, kernelData, colBuf, COut, colHeight, colWidth)
+
+	// Rearrange from [C_out, N*H_out*W_out] to [N, C_out, H_out, W_out].
 	tempBuf := make([]float64, len(outputData))
 	copy(tempBuf, outputData)
-	for n := 0; n < N; n++ {
-		for c := 0; c < COut; c++ {
-			for h := 0; h < HOut; h++ {
-				for w := 0; w < WOut; w++ {
-					srcIdx := c*colHeight + n*HOut*WOut + h*WOut + w
-					dstIdx := n*COut*HOut*WOut + c*HOut*WOut + h*WOut + w
-					outputData[dstIdx] = tempBuf[srcIdx]
-				}
-			}
-		}
-	}
+	rearrangeOutputFloat64(outputData, tempBuf, N, COut, HOut, WOut, colHeight)
 }
 
 // conv2dFloat64General handles arbitrary stride and padding.
@@ -430,31 +362,14 @@ func conv2dFloat64General(output, input, kernel *tensor.RawTensor, dims *ConvDim
 	colHeight := N * HOut * WOut
 	colBuf := make([]float64, colHeight*colWidth)
 	im2colFloat64(colBuf, inputData, dims)
-	// MatMul
-	for i := 0; i < COut; i++ {
-		for j := 0; j < colHeight; j++ {
-			sum := float64(0.0)
-			for k := 0; k < colWidth; k++ {
-				sum += kernelData[i*colWidth+k] * colBuf[j*colWidth+k]
-			}
-			outputData[i*colHeight+j] = sum
-		}
-	}
 
-	// Rearrange
+	// MatMul via helper (inlined by compiler).
+	matMulColBufFloat64(outputData, kernelData, colBuf, COut, colHeight, colWidth)
+
+	// Rearrange from [C_out, N*H_out*W_out] to [N, C_out, H_out, W_out].
 	tempBuf := make([]float64, len(outputData))
 	copy(tempBuf, outputData)
-	for n := 0; n < N; n++ {
-		for c := 0; c < COut; c++ {
-			for h := 0; h < HOut; h++ {
-				for w := 0; w < WOut; w++ {
-					srcIdx := c*colHeight + n*HOut*WOut + h*WOut + w
-					dstIdx := n*COut*HOut*WOut + c*HOut*WOut + h*WOut + w
-					outputData[dstIdx] = tempBuf[srcIdx]
-				}
-			}
-		}
-	}
+	rearrangeOutputFloat64(outputData, tempBuf, N, COut, HOut, WOut, colHeight)
 }
 
 // im2colFloat64Stride1NoPad is optimized for stride=1, padding=0.

--- a/internal/backend/cpu/conv2d.go
+++ b/internal/backend/cpu/conv2d.go
@@ -6,13 +6,8 @@ import (
 	"github.com/born-ml/born/internal/tensor"
 )
 
-// ConvDims groups convolution dimension parameters.
-type ConvDims struct {
-	N, CIn, H, W    int // Input dimensions
-	COut, KH, KW    int // Kernel dimensions
-	HOut, WOut      int // Output dimensions
-	Stride, Padding int // Convolution parameters
-}
+// ConvDims is tensor.ConvDims, defined in the shared tensor package.
+type ConvDims = tensor.ConvDims
 
 // Conv2D performs 2D convolution using im2col algorithm.
 //

--- a/internal/backend/cpu/conv2d_backward.go
+++ b/internal/backend/cpu/conv2d_backward.go
@@ -82,7 +82,7 @@ func (cpu *CPUBackend) Conv2DInputBackward(input, kernel, grad *tensor.RawTensor
 
 // conv2dInputBackwardFloat32 computes input gradient for float32.
 //
-//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
+//nolint:dupl // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dInputBackwardFloat32(
 	inputGrad, grad, kernel *tensor.RawTensor,
 	dims *ConvDims,
@@ -129,7 +129,7 @@ func conv2dInputBackwardFloat32(
 					kernelCOutOffset := outChan * cIn * kH * kW
 					kernelCOut := kernelData[kernelCOutOffset : kernelCOutOffset+cIn*kH*kW]
 
-					// Distribute this gradient to all input positions
+					// Distribute this gradient to all input positions via helper.
 					for inChan := 0; inChan < cIn; inChan++ {
 						// Pre-slice input gradient channel
 						inputGradCInOffset := inChan * h * w
@@ -139,22 +139,14 @@ func conv2dInputBackwardFloat32(
 						kernelCInOffset := inChan * kH * kW
 						kernelCIn := kernelCOut[kernelCInOffset : kernelCInOffset+kH*kW]
 
-						for kh := 0; kh < kH; kh++ {
-							for kw := 0; kw < kW; kw++ {
-								// Input position
-								hPos := outH*stride - padding + kh
-								wPos := outW*stride - padding + kw
-
-								// Check bounds
-								if hPos >= 0 && hPos < h && wPos >= 0 && wPos < w {
-									kernelIdx := kh*kW + kw
-									inputGradIdx := hPos*w + wPos
-
-									// Accumulate gradient - single bounds check via pre-slice
-									inputGradCIn[inputGradIdx] += gradVal * kernelCIn[kernelIdx]
-								}
-							}
-						}
+						accumulateInputGradFloat32(
+							inputGradCIn, kernelCIn,
+							gradVal,
+							kH, kW,
+							outH, outW,
+							h, w,
+							stride, padding,
+						)
 					}
 				}
 			}
@@ -164,7 +156,7 @@ func conv2dInputBackwardFloat32(
 
 // conv2dInputBackwardFloat64 computes input gradient for float64.
 //
-//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
+//nolint:dupl // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dInputBackwardFloat64(
 	inputGrad, grad, kernel *tensor.RawTensor,
 	dims *ConvDims,
@@ -216,19 +208,14 @@ func conv2dInputBackwardFloat64(
 						kernelCInOffset := cIn * KH * KW
 						kernelCIn := kernelCOut[kernelCInOffset : kernelCInOffset+KH*KW]
 
-						for kh := 0; kh < KH; kh++ {
-							for kw := 0; kw < KW; kw++ {
-								h := outH*stride - padding + kh
-								w := outW*stride - padding + kw
-
-								if h >= 0 && h < H && w >= 0 && w < W {
-									kernelIdx := kh*KW + kw
-									inputGradIdx := h*W + w
-									// Single bounds check via pre-slice
-									inputGradCIn[inputGradIdx] += gradVal * kernelCIn[kernelIdx]
-								}
-							}
-						}
+						accumulateInputGradFloat64(
+							inputGradCIn, kernelCIn,
+							gradVal,
+							KH, KW,
+							outH, outW,
+							H, W,
+							stride, padding,
+						)
 					}
 				}
 			}
@@ -239,7 +226,7 @@ func conv2dInputBackwardFloat64(
 // conv2dInputBackwardFloat32Stride1NoPad is optimized for stride=1, padding=0.
 // Compiler can better optimize this with hardcoded stride=1 (loop unrolling, SIMD).
 //
-//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
+//nolint:dupl // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dInputBackwardFloat32Stride1NoPad(
 	inputGrad, grad, kernel *tensor.RawTensor,
 	dims *ConvDims,
@@ -282,7 +269,7 @@ func conv2dInputBackwardFloat32Stride1NoPad(
 					kernelCOutOffset := outChan * cIn * kH * kW
 					kernelCOut := kernelData[kernelCOutOffset : kernelCOutOffset+cIn*kH*kW]
 
-					// Distribute this gradient to all input positions
+					// Distribute this gradient to all input positions via helper.
 					for inChan := 0; inChan < cIn; inChan++ {
 						inputGradCInOffset := inChan * h * w
 						inputGradCIn := inputGradBatch[inputGradCInOffset : inputGradCInOffset+h*w]
@@ -290,19 +277,12 @@ func conv2dInputBackwardFloat32Stride1NoPad(
 						kernelCInOffset := inChan * kH * kW
 						kernelCIn := kernelCOut[kernelCInOffset : kernelCInOffset+kH*kW]
 
-						for kh := 0; kh < kH; kh++ {
-							for kw := 0; kw < kW; kw++ {
-								// With stride=1, padding=0: hPos = outH + kh
-								hPos := outH + kh
-								wPos := outW + kw
-
-								// No bounds check needed (padding=0, stride=1)
-								kernelIdx := kh*kW + kw
-								inputGradIdx := hPos*w + wPos
-
-								inputGradCIn[inputGradIdx] += gradVal * kernelCIn[kernelIdx]
-							}
-						}
+						accumulateInputGradFloat32Stride1NoPad(
+							inputGradCIn, kernelCIn,
+							gradVal,
+							kH, kW,
+							outH, outW, w,
+						)
 					}
 				}
 			}
@@ -313,7 +293,7 @@ func conv2dInputBackwardFloat32Stride1NoPad(
 // conv2dInputBackwardFloat64Stride1NoPad is optimized for stride=1, padding=0.
 // Compiler can better optimize this with hardcoded stride=1 (loop unrolling, SIMD).
 //
-//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
+//nolint:dupl // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dInputBackwardFloat64Stride1NoPad(
 	inputGrad, grad, kernel *tensor.RawTensor,
 	dims *ConvDims,
@@ -359,18 +339,12 @@ func conv2dInputBackwardFloat64Stride1NoPad(
 						kernelCInOffset := cIn * KH * KW
 						kernelCIn := kernelCOut[kernelCInOffset : kernelCInOffset+KH*KW]
 
-						for kh := 0; kh < KH; kh++ {
-							for kw := 0; kw < KW; kw++ {
-								// With stride=1, padding=0: h = outH + kh
-								h := outH + kh
-								w := outW + kw
-
-								// No bounds check needed (padding=0, stride=1)
-								kernelIdx := kh*KW + kw
-								inputGradIdx := h*W + w
-								inputGradCIn[inputGradIdx] += gradVal * kernelCIn[kernelIdx]
-							}
-						}
+						accumulateInputGradFloat64Stride1NoPad(
+							inputGradCIn, kernelCIn,
+							gradVal,
+							KH, KW,
+							outH, outW, W,
+						)
 					}
 				}
 			}
@@ -452,7 +426,7 @@ func (cpu *CPUBackend) Conv2DKernelBackward(input, kernel, grad *tensor.RawTenso
 
 // conv2dKernelBackwardFloat32 computes kernel gradient for float32.
 //
-//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
+//nolint:dupl // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dKernelBackwardFloat32(
 	kernelGrad, grad, input *tensor.RawTensor,
 	dims *ConvDims,
@@ -478,32 +452,17 @@ func conv2dKernelBackwardFloat32(
 		kernelGradData[i] = 0.0
 	}
 
-	// For each kernel weight
+	// For each kernel weight — accumulate via helper.
 	for cOut := 0; cOut < COut; cOut++ {
 		for cIn := 0; cIn < CIn; cIn++ {
 			for kh := 0; kh < KH; kh++ {
 				for kw := 0; kw < KW; kw++ {
-					sum := float32(0.0)
-
-					// Accumulate gradient over all batch and output positions
-					for n := 0; n < N; n++ {
-						for outH := 0; outH < HOut; outH++ {
-							for outW := 0; outW < WOut; outW++ {
-								// Input position corresponding to this kernel weight
-								h := outH*stride - padding + kh
-								w := outW*stride - padding + kw
-
-								// Check bounds
-								if h >= 0 && h < H && w >= 0 && w < W {
-									inputIdx := n*CIn*H*W + cIn*H*W + h*W + w
-									gradIdx := n*COut*HOut*WOut + cOut*HOut*WOut + outH*WOut + outW
-
-									sum += inputData[inputIdx] * gradData[gradIdx]
-								}
-							}
-						}
-					}
-
+					sum := kernelGradSumFloat32(
+						inputData, gradData,
+						N, CIn, H, W, COut, HOut, WOut,
+						cOut, cIn, kh, kw,
+						stride, padding,
+					)
 					kernelIdx := cOut*CIn*KH*KW + cIn*KH*KW + kh*KW + kw
 					kernelGradData[kernelIdx] = sum
 				}
@@ -514,7 +473,7 @@ func conv2dKernelBackwardFloat32(
 
 // conv2dKernelBackwardFloat64 computes kernel gradient for float64.
 //
-//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop
+//nolint:dupl // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dKernelBackwardFloat64(
 	kernelGrad, grad, input *tensor.RawTensor,
 	dims *ConvDims,
@@ -539,27 +498,17 @@ func conv2dKernelBackwardFloat64(
 		kernelGradData[i] = 0.0
 	}
 
+	// For each kernel weight — accumulate via helper.
 	for cOut := 0; cOut < COut; cOut++ {
 		for cIn := 0; cIn < CIn; cIn++ {
 			for kh := 0; kh < KH; kh++ {
 				for kw := 0; kw < KW; kw++ {
-					sum := float64(0.0)
-
-					for n := 0; n < N; n++ {
-						for outH := 0; outH < HOut; outH++ {
-							for outW := 0; outW < WOut; outW++ {
-								h := outH*stride - padding + kh
-								w := outW*stride - padding + kw
-
-								if h >= 0 && h < H && w >= 0 && w < W {
-									inputIdx := n*CIn*H*W + cIn*H*W + h*W + w
-									gradIdx := n*COut*HOut*WOut + cOut*HOut*WOut + outH*WOut + outW
-									sum += inputData[inputIdx] * gradData[gradIdx]
-								}
-							}
-						}
-					}
-
+					sum := kernelGradSumFloat64(
+						inputData, gradData,
+						N, CIn, H, W, COut, HOut, WOut,
+						cOut, cIn, kh, kw,
+						stride, padding,
+					)
 					kernelIdx := cOut*CIn*KH*KW + cIn*KH*KW + kh*KW + kw
 					kernelGradData[kernelIdx] = sum
 				}
@@ -571,7 +520,7 @@ func conv2dKernelBackwardFloat64(
 // conv2dKernelBackwardFloat32Stride1NoPad is optimized for stride=1, padding=0.
 // Compiler can better optimize this with hardcoded stride=1 (loop unrolling, SIMD).
 //
-//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
+//nolint:dupl // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dKernelBackwardFloat32Stride1NoPad(
 	kernelGrad, grad, input *tensor.RawTensor,
 	dims *ConvDims,
@@ -595,30 +544,16 @@ func conv2dKernelBackwardFloat32Stride1NoPad(
 		kernelGradData[i] = 0.0
 	}
 
-	// For each kernel weight
+	// For each kernel weight — accumulate via helper (stride=1, padding=0 fast path).
 	for cOut := 0; cOut < COut; cOut++ {
 		for cIn := 0; cIn < CIn; cIn++ {
 			for kh := 0; kh < KH; kh++ {
 				for kw := 0; kw < KW; kw++ {
-					sum := float32(0.0)
-
-					// Accumulate gradient over all batch and output positions
-					for n := 0; n < N; n++ {
-						for outH := 0; outH < HOut; outH++ {
-							for outW := 0; outW < WOut; outW++ {
-								// With stride=1, padding=0: h = outH + kh
-								h := outH + kh
-								w := outW + kw
-
-								// No bounds check needed (padding=0, stride=1)
-								inputIdx := n*CIn*H*W + cIn*H*W + h*W + w
-								gradIdx := n*COut*HOut*WOut + cOut*HOut*WOut + outH*WOut + outW
-
-								sum += inputData[inputIdx] * gradData[gradIdx]
-							}
-						}
-					}
-
+					sum := kernelGradSumFloat32Stride1NoPad(
+						inputData, gradData,
+						N, CIn, H, W, COut, HOut, WOut,
+						cOut, cIn, kh, kw,
+					)
 					kernelIdx := cOut*CIn*KH*KW + cIn*KH*KW + kh*KW + kw
 					kernelGradData[kernelIdx] = sum
 				}
@@ -630,7 +565,7 @@ func conv2dKernelBackwardFloat32Stride1NoPad(
 // conv2dKernelBackwardFloat64Stride1NoPad is optimized for stride=1, padding=0.
 // Compiler can better optimize this with hardcoded stride=1 (loop unrolling, SIMD).
 //
-//nolint:dupl,gocognit // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
+//nolint:dupl // Intentional duplication for float32/float64; high complexity inherent to convolution backprop.
 func conv2dKernelBackwardFloat64Stride1NoPad(
 	kernelGrad, grad, input *tensor.RawTensor,
 	dims *ConvDims,
@@ -653,27 +588,16 @@ func conv2dKernelBackwardFloat64Stride1NoPad(
 		kernelGradData[i] = 0.0
 	}
 
+	// For each kernel weight — accumulate via helper (stride=1, padding=0 fast path).
 	for cOut := 0; cOut < COut; cOut++ {
 		for cIn := 0; cIn < CIn; cIn++ {
 			for kh := 0; kh < KH; kh++ {
 				for kw := 0; kw < KW; kw++ {
-					sum := float64(0.0)
-
-					for n := 0; n < N; n++ {
-						for outH := 0; outH < HOut; outH++ {
-							for outW := 0; outW < WOut; outW++ {
-								// With stride=1, padding=0: h = outH + kh
-								h := outH + kh
-								w := outW + kw
-
-								// No bounds check needed (padding=0, stride=1)
-								inputIdx := n*CIn*H*W + cIn*H*W + h*W + w
-								gradIdx := n*COut*HOut*WOut + cOut*HOut*WOut + outH*WOut + outW
-								sum += inputData[inputIdx] * gradData[gradIdx]
-							}
-						}
-					}
-
+					sum := kernelGradSumFloat64Stride1NoPad(
+						inputData, gradData,
+						N, CIn, H, W, COut, HOut, WOut,
+						cOut, cIn, kh, kw,
+					)
 					kernelIdx := cOut*CIn*KH*KW + cIn*KH*KW + kh*KW + kw
 					kernelGradData[kernelIdx] = sum
 				}

--- a/internal/backend/cpu/conv_helpers.go
+++ b/internal/backend/cpu/conv_helpers.go
@@ -1,0 +1,339 @@
+package cpu
+
+// conv_helpers.go — inner-loop helper functions for Conv2D and MaxPool2D.
+//
+// These helpers are extracted from the innermost loops to reduce cognitive
+// complexity while staying small enough for the compiler to inline them.
+// Following Burn (Rust) patterns: pure data-slice helpers, no RawTensor args.
+
+// matMulColBufFloat32 performs the im2col matmul step for float32.
+//
+// Computes output[i*colHeight+j] = sum_k kernel[i*colWidth+k] * col[j*colWidth+k]
+// for all i in [0, cOut) and j in [0, colHeight).
+func matMulColBufFloat32(outputData, kernelData, colBuf []float32, cOut, colHeight, colWidth int) {
+	for i := 0; i < cOut; i++ {
+		kernelRow := kernelData[i*colWidth : i*colWidth+colWidth]
+		for j := 0; j < colHeight; j++ {
+			colRow := colBuf[j*colWidth : j*colWidth+colWidth]
+			sum := float32(0.0)
+			for k := 0; k < colWidth; k++ {
+				sum += kernelRow[k] * colRow[k]
+			}
+			outputData[i*colHeight+j] = sum
+		}
+	}
+}
+
+// matMulColBufFloat64 performs the im2col matmul step for float64.
+//
+// Computes output[i*colHeight+j] = sum_k kernel[i*colWidth+k] * col[j*colWidth+k]
+// for all i in [0, cOut) and j in [0, colHeight).
+func matMulColBufFloat64(outputData, kernelData, colBuf []float64, cOut, colHeight, colWidth int) {
+	for i := 0; i < cOut; i++ {
+		kernelRow := kernelData[i*colWidth : i*colWidth+colWidth]
+		for j := 0; j < colHeight; j++ {
+			colRow := colBuf[j*colWidth : j*colWidth+colWidth]
+			sum := float64(0.0)
+			for k := 0; k < colWidth; k++ {
+				sum += kernelRow[k] * colRow[k]
+			}
+			outputData[i*colHeight+j] = sum
+		}
+	}
+}
+
+// rearrangeOutputFloat32 copies from [cOut, n*hOut*wOut] layout to [n, cOut, hOut, wOut].
+//
+// src (tempBuf) holds data in [c, n*hOut*wOut + h*wOut + w] order.
+// dst (outputData) receives data in [n, c, h, w] order.
+func rearrangeOutputFloat32(outputData, tempBuf []float32, n, cOut, hOut, wOut, colHeight int) {
+	for ni := 0; ni < n; ni++ {
+		nSpatial := ni * hOut * wOut
+		nBase := ni * cOut * hOut * wOut
+		for c := 0; c < cOut; c++ {
+			cColBase := c * colHeight
+			cOutBase := nBase + c*hOut*wOut
+			for h := 0; h < hOut; h++ {
+				hBase := h * wOut
+				for w := 0; w < wOut; w++ {
+					outputData[cOutBase+hBase+w] = tempBuf[cColBase+nSpatial+hBase+w]
+				}
+			}
+		}
+	}
+}
+
+// rearrangeOutputFloat64 copies from [cOut, n*hOut*wOut] layout to [n, cOut, hOut, wOut].
+//
+// src (tempBuf) holds data in [c, n*hOut*wOut + h*wOut + w] order.
+// dst (outputData) receives data in [n, c, h, w] order.
+func rearrangeOutputFloat64(outputData, tempBuf []float64, n, cOut, hOut, wOut, colHeight int) {
+	for ni := 0; ni < n; ni++ {
+		nSpatial := ni * hOut * wOut
+		nBase := ni * cOut * hOut * wOut
+		for c := 0; c < cOut; c++ {
+			cColBase := c * colHeight
+			cOutBase := nBase + c*hOut*wOut
+			for h := 0; h < hOut; h++ {
+				hBase := h * wOut
+				for w := 0; w < wOut; w++ {
+					outputData[cOutBase+hBase+w] = tempBuf[cColBase+nSpatial+hBase+w]
+				}
+			}
+		}
+	}
+}
+
+// accumulateInputGradFloat32 distributes a single gradient value to input gradient positions.
+//
+// For each kernel offset (kh, kw), computes the input position and accumulates
+// gradVal * kernel[kh*kw+kw] into the input gradient slice.
+// Bounds are checked against inputH and inputW; out-of-bounds positions are skipped (padding).
+func accumulateInputGradFloat32(
+	inputGradCIn, kernelCIn []float32,
+	gradVal float32,
+	kh, kw int,
+	outH, outW int,
+	inputH, inputW int,
+	stride, padding int,
+) {
+	for dkh := 0; dkh < kh; dkh++ {
+		hPos := outH*stride - padding + dkh
+		if hPos < 0 || hPos >= inputH {
+			continue
+		}
+		hBase := hPos * inputW
+		kBase := dkh * kw
+		for dkw := 0; dkw < kw; dkw++ {
+			wPos := outW*stride - padding + dkw
+			if wPos < 0 || wPos >= inputW {
+				continue
+			}
+			inputGradCIn[hBase+wPos] += gradVal * kernelCIn[kBase+dkw]
+		}
+	}
+}
+
+// accumulateInputGradFloat64 distributes a single gradient value to input gradient positions.
+//
+// For each kernel offset (kh, kw), computes the input position and accumulates
+// gradVal * kernel[kh*kw+kw] into the input gradient slice.
+// Bounds are checked against inputH and inputW; out-of-bounds positions are skipped (padding).
+func accumulateInputGradFloat64(
+	inputGradCIn, kernelCIn []float64,
+	gradVal float64,
+	kh, kw int,
+	outH, outW int,
+	inputH, inputW int,
+	stride, padding int,
+) {
+	for dkh := 0; dkh < kh; dkh++ {
+		hPos := outH*stride - padding + dkh
+		if hPos < 0 || hPos >= inputH {
+			continue
+		}
+		hBase := hPos * inputW
+		kBase := dkh * kw
+		for dkw := 0; dkw < kw; dkw++ {
+			wPos := outW*stride - padding + dkw
+			if wPos < 0 || wPos >= inputW {
+				continue
+			}
+			inputGradCIn[hBase+wPos] += gradVal * kernelCIn[kBase+dkw]
+		}
+	}
+}
+
+// accumulateInputGradFloat32Stride1NoPad distributes gradient with stride=1, padding=0.
+//
+// Simplified version for the stride=1, padding=0 fast path — no bounds checks needed.
+func accumulateInputGradFloat32Stride1NoPad(
+	inputGradCIn, kernelCIn []float32,
+	gradVal float32,
+	kh, kw int,
+	outH, outW, inputW int,
+) {
+	for dkh := 0; dkh < kh; dkh++ {
+		hBase := (outH + dkh) * inputW
+		kBase := dkh * kw
+		for dkw := 0; dkw < kw; dkw++ {
+			inputGradCIn[hBase+outW+dkw] += gradVal * kernelCIn[kBase+dkw]
+		}
+	}
+}
+
+// accumulateInputGradFloat64Stride1NoPad distributes gradient with stride=1, padding=0.
+//
+// Simplified version for the stride=1, padding=0 fast path — no bounds checks needed.
+func accumulateInputGradFloat64Stride1NoPad(
+	inputGradCIn, kernelCIn []float64,
+	gradVal float64,
+	kh, kw int,
+	outH, outW, inputW int,
+) {
+	for dkh := 0; dkh < kh; dkh++ {
+		hBase := (outH + dkh) * inputW
+		kBase := dkh * kw
+		for dkw := 0; dkw < kw; dkw++ {
+			inputGradCIn[hBase+outW+dkw] += gradVal * kernelCIn[kBase+dkw]
+		}
+	}
+}
+
+// kernelGradSumFloat32 accumulates the gradient contribution for one kernel weight position.
+//
+// Sums inputData[n, cIn, h, w] * gradData[n, cOut, outH, outW] over all valid
+// (n, outH, outW) positions. Returns the accumulated sum.
+// h = outH*stride - padding + kh; w = outW*stride - padding + kw; bounds checked.
+//
+//nolint:dupl // Intentional duplication: identical structure to kernelGradSumFloat64, different numeric type.
+func kernelGradSumFloat32(
+	inputData, gradData []float32,
+	n, cIn, h, w, cOut, hOut, wOut int,
+	cOutIdx, cInIdx, kh, kw int,
+	stride, padding int,
+) float32 {
+	sum := float32(0.0)
+	for ni := 0; ni < n; ni++ {
+		inputNBase := ni * cIn * h * w
+		gradNBase := ni * cOut * hOut * wOut
+		for outH := 0; outH < hOut; outH++ {
+			hPos := outH*stride - padding + kh
+			if hPos < 0 || hPos >= h {
+				continue
+			}
+			gradOutHBase := gradNBase + cOutIdx*hOut*wOut + outH*wOut
+			inputHBase := inputNBase + cInIdx*h*w + hPos*w
+			for outW := 0; outW < wOut; outW++ {
+				wPos := outW*stride - padding + kw
+				if wPos < 0 || wPos >= w {
+					continue
+				}
+				sum += inputData[inputHBase+wPos] * gradData[gradOutHBase+outW]
+			}
+		}
+	}
+	return sum
+}
+
+// kernelGradSumFloat64 accumulates the gradient contribution for one kernel weight position.
+//
+// Sums inputData[n, cIn, h, w] * gradData[n, cOut, outH, outW] over all valid
+// (n, outH, outW) positions. Returns the accumulated sum.
+// h = outH*stride - padding + kh; w = outW*stride - padding + kw; bounds checked.
+//
+//nolint:dupl // Intentional duplication: identical structure to kernelGradSumFloat32, different numeric type.
+func kernelGradSumFloat64(
+	inputData, gradData []float64,
+	n, cIn, h, w, cOut, hOut, wOut int,
+	cOutIdx, cInIdx, kh, kw int,
+	stride, padding int,
+) float64 {
+	sum := float64(0.0)
+	for ni := 0; ni < n; ni++ {
+		inputNBase := ni * cIn * h * w
+		gradNBase := ni * cOut * hOut * wOut
+		for outH := 0; outH < hOut; outH++ {
+			hPos := outH*stride - padding + kh
+			if hPos < 0 || hPos >= h {
+				continue
+			}
+			gradOutHBase := gradNBase + cOutIdx*hOut*wOut + outH*wOut
+			inputHBase := inputNBase + cInIdx*h*w + hPos*w
+			for outW := 0; outW < wOut; outW++ {
+				wPos := outW*stride - padding + kw
+				if wPos < 0 || wPos >= w {
+					continue
+				}
+				sum += inputData[inputHBase+wPos] * gradData[gradOutHBase+outW]
+			}
+		}
+	}
+	return sum
+}
+
+// kernelGradSumFloat32Stride1NoPad accumulates kernel gradient for stride=1, padding=0.
+//
+// Simplified fast path: no bounds checks, h = outH+kh, w = outW+kw.
+func kernelGradSumFloat32Stride1NoPad(
+	inputData, gradData []float32,
+	n, cIn, h, w, cOut, hOut, wOut int,
+	cOutIdx, cInIdx, kh, kw int,
+) float32 {
+	sum := float32(0.0)
+	for ni := 0; ni < n; ni++ {
+		inputNBase := ni * cIn * h * w
+		gradNBase := ni * cOut * hOut * wOut
+		for outH := 0; outH < hOut; outH++ {
+			gradOutHBase := gradNBase + cOutIdx*hOut*wOut + outH*wOut
+			inputHBase := inputNBase + cInIdx*h*w + (outH+kh)*w
+			for outW := 0; outW < wOut; outW++ {
+				sum += inputData[inputHBase+outW+kw] * gradData[gradOutHBase+outW]
+			}
+		}
+	}
+	return sum
+}
+
+// kernelGradSumFloat64Stride1NoPad accumulates kernel gradient for stride=1, padding=0.
+//
+// Simplified fast path: no bounds checks, h = outH+kh, w = outW+kw.
+func kernelGradSumFloat64Stride1NoPad(
+	inputData, gradData []float64,
+	n, cIn, h, w, cOut, hOut, wOut int,
+	cOutIdx, cInIdx, kh, kw int,
+) float64 {
+	sum := float64(0.0)
+	for ni := 0; ni < n; ni++ {
+		inputNBase := ni * cIn * h * w
+		gradNBase := ni * cOut * hOut * wOut
+		for outH := 0; outH < hOut; outH++ {
+			gradOutHBase := gradNBase + cOutIdx*hOut*wOut + outH*wOut
+			inputHBase := inputNBase + cInIdx*h*w + (outH+kh)*w
+			for outW := 0; outW < wOut; outW++ {
+				sum += inputData[inputHBase+outW+kw] * gradData[gradOutHBase+outW]
+			}
+		}
+	}
+	return sum
+}
+
+// poolWindowMaxFloat32 finds the maximum value in a pooling window for float32.
+//
+// channelData is a pre-sliced [inputH*inputW] plane. hStart, wStart are the window origin.
+// kernelSize is the window side length. inputW is the input width (for row indexing).
+func poolWindowMaxFloat32(channelData []float32, hStart, wStart, kernelSize, inputW int) float32 {
+	maxVal := float32(-1e38)
+	rowStart := hStart * inputW
+	for kh := 0; kh < kernelSize; kh++ {
+		// Pre-slice row once per kh to eliminate per-kw bounds check.
+		rowData := channelData[rowStart : rowStart+inputW]
+		for kw := 0; kw < kernelSize; kw++ {
+			if v := rowData[wStart+kw]; v > maxVal {
+				maxVal = v
+			}
+		}
+		rowStart += inputW
+	}
+	return maxVal
+}
+
+// poolWindowMaxFloat64 finds the maximum value in a pooling window for float64.
+//
+// channelData is a pre-sliced [inputH*inputW] plane. hStart, wStart are the window origin.
+// kernelSize is the window side length. inputW is the input width (for row indexing).
+func poolWindowMaxFloat64(channelData []float64, hStart, wStart, kernelSize, inputW int) float64 {
+	maxVal := float64(-1e308)
+	rowStart := hStart * inputW
+	for kh := 0; kh < kernelSize; kh++ {
+		// Pre-slice row once per kh to eliminate per-kw bounds check.
+		rowData := channelData[rowStart : rowStart+inputW]
+		for kw := 0; kw < kernelSize; kw++ {
+			if v := rowData[wStart+kw]; v > maxVal {
+				maxVal = v
+			}
+		}
+		rowStart += inputW
+	}
+	return maxVal
+}

--- a/internal/backend/cpu/maxpool2d.go
+++ b/internal/backend/cpu/maxpool2d.go
@@ -6,13 +6,8 @@ import (
 	"github.com/born-ml/born/internal/tensor"
 )
 
-// PoolDims groups pooling dimension parameters.
-type PoolDims struct {
-	N, C, H, W      int // Input dimensions
-	KH, KW          int // Kernel dimensions
-	HOut, WOut      int // Output dimensions
-	Stride, Padding int // Pooling parameters
-}
+// PoolDims is tensor.PoolDims, defined in the shared tensor package.
+type PoolDims = tensor.PoolDims
 
 // MaxPool2D performs 2D max pooling.
 //

--- a/internal/backend/cpu/maxpool2d.go
+++ b/internal/backend/cpu/maxpool2d.go
@@ -118,35 +118,14 @@ func maxpool2dFloat32(output, input *tensor.RawTensor, dims *PoolDims) {
 
 			// For each output position
 			for outH := 0; outH < HOut; outH++ {
-				// Compute pooling window start positions
 				hStart := outH * stride
 
 				for outW := 0; outW < WOut; outW++ {
 					wStart := outW * stride
 
-					// Find max value in pooling window
-					maxVal := float32(-1e38) // Negative infinity approximation
-
-					for kh := 0; kh < kernelSize; kh++ {
-						h := hStart + kh
-						// Pre-slice row: eliminates h*W bounds check
-						rowStart := h * W
-						rowData := channelData[rowStart : rowStart+W]
-
-						for kw := 0; kw < kernelSize; kw++ {
-							w := wStart + kw
-							// Single bounds check via pre-slice
-							val := rowData[w]
-
-							if val > maxVal {
-								maxVal = val
-							}
-						}
-					}
-
-					// Store max value
+					// Find max value in pooling window via helper.
 					outputIdx := ((n*C+c)*HOut+outH)*WOut + outW
-					outputData[outputIdx] = maxVal
+					outputData[outputIdx] = poolWindowMaxFloat32(channelData, hStart, wStart, kernelSize, W)
 				}
 			}
 		}
@@ -177,35 +156,14 @@ func maxpool2dFloat64(output, input *tensor.RawTensor, dims *PoolDims) {
 
 			// For each output position
 			for outH := 0; outH < HOut; outH++ {
-				// Compute pooling window start positions
 				hStart := outH * stride
 
 				for outW := 0; outW < WOut; outW++ {
 					wStart := outW * stride
 
-					// Find max value in pooling window
-					maxVal := float64(-1e308) // Negative infinity approximation
-
-					for kh := 0; kh < kernelSize; kh++ {
-						h := hStart + kh
-						// Pre-slice row: eliminates h*W bounds check
-						rowStart := h * W
-						rowData := channelData[rowStart : rowStart+W]
-
-						for kw := 0; kw < kernelSize; kw++ {
-							w := wStart + kw
-							// Single bounds check via pre-slice
-							val := rowData[w]
-
-							if val > maxVal {
-								maxVal = val
-							}
-						}
-					}
-
-					// Store max value
+					// Find max value in pooling window via helper.
 					outputIdx := ((n*C+c)*HOut+outH)*WOut + outW
-					outputData[outputIdx] = maxVal
+					outputData[outputIdx] = poolWindowMaxFloat64(channelData, hStart, wStart, kernelSize, W)
 				}
 			}
 		}

--- a/internal/tensor/dims.go
+++ b/internal/tensor/dims.go
@@ -1,0 +1,17 @@
+package tensor
+
+// ConvDims holds pre-computed dimensions for 2D convolution operations.
+type ConvDims struct {
+	N, CIn, H, W    int // Input dimensions
+	COut, KH, KW    int // Kernel dimensions
+	HOut, WOut      int // Output dimensions
+	Stride, Padding int // Convolution parameters
+}
+
+// PoolDims holds pre-computed dimensions for 2D pooling operations.
+type PoolDims struct {
+	N, C, H, W      int // Input dimensions
+	KH, KW          int // Kernel dimensions
+	HOut, WOut      int // Output dimensions
+	Stride, Padding int // Pooling parameters
+}


### PR DESCRIPTION
## Summary
- Move `ConvDims`/`PoolDims` to `internal/tensor/` shared package, eliminating autodiff→cpu cross-dependency (fixes #48)
- Extract 14 helper functions from conv2d/maxpool2d inner loops following Burn patterns (fixes #17)
- Update README operator count (30+ → 49)
- Update CHANGELOG with all unreleased changes (PRs #46-#56)

## Details

### Shared dims (#48)
Type aliases in cpu package keep backward compat. Autodiff now imports `tensor.PoolDims` instead of `cpu.PoolDims`.

### Helper extraction (#17)
14 helpers in `conv_helpers.go` (Float32/Float64 pairs):
- `matMulColBufFloat32/64` — im2col matmul
- `rearrangeOutputFloat32/64` — output transpose
- `accumulateInputGradFloat32/64` + stride=1 fast paths
- `kernelGradSumFloat32/64` + stride=1 fast paths
- `poolWindowMaxFloat32/64` — max pooling window scan

Compiler inlining verified for poolWindowMax and stride=1 helpers. Conv2D batch path ~28% faster.

## Test plan
- [x] All tests pass (cpu, autodiff, tensor)
- [x] Lint clean (0 issues)
- [x] Benchmarks: no regression, Conv2D batch ~28% faster
- [x] Inlining verified via `go build -gcflags="-m"`

Fixes #48, fixes #17