### PR TITLE
feature(tensor): implement clamp op

### DIFF
--- a/internal/autodiff/autodiff.go
+++ b/internal/autodiff/autodiff.go
@@ -967,6 +967,22 @@ func (b *AutodiffBackend[B]) Gather(x *tensor.RawTensor, dim int, index *tensor.
 	return result
 }
 
+// Clamp restricts tensor values element-wise to [minBound, maxBound].
+func (b *AutodiffBackend[B]) Clamp(x *tensor.RawTensor, minBound, maxBound any) *tensor.RawTensor {
+	defer x.ForceNonUnique()()
+
+	// Perform forward pass
+	result := b.inner.Clamp(x, minBound, maxBound)
+
+	// Record operation for gradient computation
+	if b.tape.IsRecording() {
+		op := ops.NewClampOp(x, minBound, maxBound, result)
+		b.tape.Record(op)
+	}
+
+	return result
+}
+
 // Where performs conditional element selection.
 //
 // output[i] = x[i] if condition[i] else y[i]

--- a/internal/autodiff/ops/clamp.go
+++ b/internal/autodiff/ops/clamp.go
@@ -33,8 +33,6 @@ func NewClampOp(input *tensor.RawTensor, minBound, maxBound any, output *tensor.
 func (op *ClampOp) Backward(outputGrad *tensor.RawTensor, backend tensor.Backend) []*tensor.RawTensor {
 	input := op.input
 
-	var maskedGrad *tensor.RawTensor
-
 	switch input.DType() {
 	case tensor.Int32:
 		minBound := tensor.CheckScalarDtype[int32](op.minBound)

--- a/internal/autodiff/ops/clamp.go
+++ b/internal/autodiff/ops/clamp.go
@@ -37,39 +37,30 @@ func (op *ClampOp) Backward(outputGrad *tensor.RawTensor, backend tensor.Backend
 
 	switch input.DType() {
 	case tensor.Int32:
-		minBound, maxBound := checkBoundsDtype[int32](op.minBound, op.maxBound)
+		minBound := tensor.CheckScalarDtype[int32](op.minBound)
+		maxBound := tensor.CheckScalarDtype[int32](op.maxBound)
 		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
 		return []*tensor.RawTensor{maskedGrad}
 	case tensor.Int64:
-		minBound, maxBound := checkBoundsDtype[int64](op.minBound, op.maxBound)
+		minBound := tensor.CheckScalarDtype[int64](op.minBound)
+		maxBound := tensor.CheckScalarDtype[int64](op.maxBound)
 		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
 		return []*tensor.RawTensor{maskedGrad}
 
 	case tensor.Float32:
-		minBound, maxBound := checkBoundsDtype[float32](op.minBound, op.maxBound)
+		minBound := tensor.CheckScalarDtype[float32](op.minBound)
+		maxBound := tensor.CheckScalarDtype[float32](op.maxBound)
 		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
 		return []*tensor.RawTensor{maskedGrad}
 
 	case tensor.Float64:
-		minBound, maxBound := checkBoundsDtype[float64](op.minBound, op.maxBound)
+		minBound := tensor.CheckScalarDtype[float64](op.minBound)
+		maxBound := tensor.CheckScalarDtype[float64](op.maxBound)
 		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
 		return []*tensor.RawTensor{maskedGrad}
 	default:
 		panic("clamp: unsupported dtype (only int32/int64/float32/float64 supported)")
 	}
-}
-
-func checkBoundsDtype[T int32 | int64 | float32 | float64](minBound, maxBound any) (T, T) {
-	minCasted, ok := minBound.(T)
-	if !ok {
-		panic(fmt.Sprintf("clamp: expected %T min bound, got %T", new(T), minBound))
-	}
-	maxCasted, ok := maxBound.(T)
-	if !ok {
-		panic(fmt.Sprintf("clamp: expected %T max bound, got %T", new(T), maxBound))
-	}
-
-	return minCasted, maxCasted
 }
 
 func clampBackwardGeneric[T int32 | int64 | float32 | float64](outputGrad, input *tensor.RawTensor, minBound, maxBound T, backend tensor.Backend) *tensor.RawTensor {

--- a/internal/autodiff/ops/clamp.go
+++ b/internal/autodiff/ops/clamp.go
@@ -1,0 +1,85 @@
+package ops
+
+import (
+	"github.com/born-ml/born/internal/tensor"
+)
+
+// ClampOp represents the clamp operation: y = clamp(x, min, max).
+//
+// Backward pass:
+//   - d(clamp(x, min, max))/dx = 1 if min <= x <= max, else 0
+//   - grad_input = grad_output * (1 if min <= input <= max, else 0)
+type ClampOp struct {
+	input    *tensor.RawTensor // x
+	minBound any               // min value
+	maxBound any               // max value
+	output   *tensor.RawTensor // clamp(x, min, max)
+}
+
+// NewClampOp creates a new ClampOp.
+func NewClampOp(input *tensor.RawTensor, minBound, maxBound any, output *tensor.RawTensor) *ClampOp {
+	return &ClampOp{
+		input:    input,
+		minBound: minBound,
+		maxBound: maxBound,
+		output:   output,
+	}
+}
+
+// Backward computes input gradient for clamp.
+//
+// Since d(clamp(x, min, max))/dx = 1 if min <= x <= max, else 0:
+// grad_input = grad_output * (1 if min <= input <= max, else 0).
+func (op *ClampOp) Backward(outputGrad *tensor.RawTensor, backend tensor.Backend) []*tensor.RawTensor {
+	input := op.input
+	minBound := op.minBound
+	maxBound := op.maxBound
+
+	var maskedGrad *tensor.RawTensor
+
+	switch input.DType() {
+	case tensor.Int32:
+		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(int32), maxBound.(int32), backend)
+	case tensor.Int64:
+		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(int64), maxBound.(int64), backend)
+
+	case tensor.Float32:
+		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(float32), maxBound.(float32), backend)
+
+	case tensor.Float64:
+		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(float64), maxBound.(float64), backend)
+	default:
+		panic("clamp: unsupported dtype (only int32/int64/float32/float64 supported)")
+	}
+
+	return []*tensor.RawTensor{maskedGrad}
+}
+
+func clampBackwardGeneric[T int32 | int64 | float32 | float64](outputGrad, input *tensor.RawTensor, minBound, maxBound T, backend tensor.Backend) *tensor.RawTensor {
+	minValues := tensor.Full(input.Shape(), minBound, backend).Raw()
+	maxValues := tensor.Full(input.Shape(), maxBound, backend).Raw()
+
+	ones := tensor.Ones[T](input.Shape(), backend).Raw()
+	zeros := tensor.Zeros[T](input.Shape(), backend).Raw()
+
+	// Check if original input is within bounds: min <= input <= max
+	minMask := backend.GreaterEqual(input, minValues) // bool where input >= min
+	maxMask := backend.LowerEqual(input, maxValues)   // bool where input <= max
+	combinedMask := backend.And(minMask, maxMask)     // bool where min <= input <= max
+
+	// Convert bool mask to dtype T for multiplication
+	mask := backend.Where(combinedMask, ones, zeros)
+	maskedGrad := backend.Mul(outputGrad, mask) // grad_output * mask
+
+	return maskedGrad
+}
+
+// Inputs returns the input tensor [x].
+func (op *ClampOp) Inputs() []*tensor.RawTensor {
+	return []*tensor.RawTensor{op.input}
+}
+
+// Output returns the output tensor clamp(x, min, max).
+func (op *ClampOp) Output() *tensor.RawTensor {
+	return op.output
+}

--- a/internal/autodiff/ops/clamp.go
+++ b/internal/autodiff/ops/clamp.go
@@ -1,8 +1,6 @@
 package ops
 
 import (
-	"fmt"
-
 	"github.com/born-ml/born/internal/tensor"
 )
 
@@ -34,48 +32,44 @@ func NewClampOp(input *tensor.RawTensor, minBound, maxBound any, output *tensor.
 // grad_input = grad_output * (1 if min <= input <= max, else 0).
 func (op *ClampOp) Backward(outputGrad *tensor.RawTensor, backend tensor.Backend) []*tensor.RawTensor {
 	input := op.input
+	minBound := op.minBound
+	maxBound := op.maxBound
+
+	var maskedGrad *tensor.RawTensor
 
 	switch input.DType() {
 	case tensor.Int32:
-		minBound := tensor.CheckScalarDtype[int32](op.minBound)
-		maxBound := tensor.CheckScalarDtype[int32](op.maxBound)
-		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
-		return []*tensor.RawTensor{maskedGrad}
+		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(int32), maxBound.(int32), backend)
 	case tensor.Int64:
-		minBound := tensor.CheckScalarDtype[int64](op.minBound)
-		maxBound := tensor.CheckScalarDtype[int64](op.maxBound)
-		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
-		return []*tensor.RawTensor{maskedGrad}
+		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(int64), maxBound.(int64), backend)
 
 	case tensor.Float32:
-		minBound := tensor.CheckScalarDtype[float32](op.minBound)
-		maxBound := tensor.CheckScalarDtype[float32](op.maxBound)
-		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
-		return []*tensor.RawTensor{maskedGrad}
+		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(float32), maxBound.(float32), backend)
 
 	case tensor.Float64:
-		minBound := tensor.CheckScalarDtype[float64](op.minBound)
-		maxBound := tensor.CheckScalarDtype[float64](op.maxBound)
-		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
-		return []*tensor.RawTensor{maskedGrad}
+		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(float64), maxBound.(float64), backend)
 	default:
 		panic("clamp: unsupported dtype (only int32/int64/float32/float64 supported)")
 	}
+
+	return []*tensor.RawTensor{maskedGrad}
 }
 
 func clampBackwardGeneric[T int32 | int64 | float32 | float64](outputGrad, input *tensor.RawTensor, minBound, maxBound T, backend tensor.Backend) *tensor.RawTensor {
 	minValues := tensor.Full(input.Shape(), minBound, backend).Raw()
 	maxValues := tensor.Full(input.Shape(), maxBound, backend).Raw()
 
-	minMask := backend.GreaterEqual(input, minValues)
-	maxMask := backend.LowerEqual(input, maxValues)
-	combinedMask := backend.And(minMask, maxMask)
+	ones := tensor.Ones[T](input.Shape(), backend).Raw()
+	zeros := tensor.Zeros[T](input.Shape(), backend).Raw()
 
-	maskNumeric, err := tensor.Cast(combinedMask, input.DType())
-	if err != nil {
-		panic(fmt.Sprintf("clamp: failed to cast mask: %v", err))
-	}
-	maskedGrad := backend.Mul(outputGrad, maskNumeric)
+	// Check if original input is within bounds: min <= input <= max
+	minMask := backend.GreaterEqual(input, minValues) // bool where input >= min
+	maxMask := backend.LowerEqual(input, maxValues)   // bool where input <= max
+	combinedMask := backend.And(minMask, maxMask)     // bool where min <= input <= max
+
+	// Convert bool mask to dtype T for multiplication
+	mask := backend.Where(combinedMask, ones, zeros)
+	maskedGrad := backend.Mul(outputGrad, mask) // grad_output * mask
 
 	return maskedGrad
 }

--- a/internal/autodiff/ops/clamp.go
+++ b/internal/autodiff/ops/clamp.go
@@ -1,6 +1,8 @@
 package ops
 
 import (
+	"fmt"
+
 	"github.com/born-ml/born/internal/tensor"
 )
 
@@ -32,44 +34,57 @@ func NewClampOp(input *tensor.RawTensor, minBound, maxBound any, output *tensor.
 // grad_input = grad_output * (1 if min <= input <= max, else 0).
 func (op *ClampOp) Backward(outputGrad *tensor.RawTensor, backend tensor.Backend) []*tensor.RawTensor {
 	input := op.input
-	minBound := op.minBound
-	maxBound := op.maxBound
-
-	var maskedGrad *tensor.RawTensor
 
 	switch input.DType() {
 	case tensor.Int32:
-		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(int32), maxBound.(int32), backend)
+		minBound, maxBound := checkBoundsDtype[int32](op.minBound, op.maxBound)
+		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
+		return []*tensor.RawTensor{maskedGrad}
 	case tensor.Int64:
-		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(int64), maxBound.(int64), backend)
+		minBound, maxBound := checkBoundsDtype[int64](op.minBound, op.maxBound)
+		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
+		return []*tensor.RawTensor{maskedGrad}
 
 	case tensor.Float32:
-		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(float32), maxBound.(float32), backend)
+		minBound, maxBound := checkBoundsDtype[float32](op.minBound, op.maxBound)
+		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
+		return []*tensor.RawTensor{maskedGrad}
 
 	case tensor.Float64:
-		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(float64), maxBound.(float64), backend)
+		minBound, maxBound := checkBoundsDtype[float64](op.minBound, op.maxBound)
+		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
+		return []*tensor.RawTensor{maskedGrad}
 	default:
 		panic("clamp: unsupported dtype (only int32/int64/float32/float64 supported)")
 	}
+}
 
-	return []*tensor.RawTensor{maskedGrad}
+func checkBoundsDtype[T int32 | int64 | float32 | float64](minBound, maxBound any) (T, T) {
+	minCasted, ok := minBound.(T)
+	if !ok {
+		panic(fmt.Sprintf("clamp: expected %T min bound, got %T", new(T), minBound))
+	}
+	maxCasted, ok := maxBound.(T)
+	if !ok {
+		panic(fmt.Sprintf("clamp: expected %T max bound, got %T", new(T), maxBound))
+	}
+
+	return minCasted, maxCasted
 }
 
 func clampBackwardGeneric[T int32 | int64 | float32 | float64](outputGrad, input *tensor.RawTensor, minBound, maxBound T, backend tensor.Backend) *tensor.RawTensor {
 	minValues := tensor.Full(input.Shape(), minBound, backend).Raw()
 	maxValues := tensor.Full(input.Shape(), maxBound, backend).Raw()
 
-	ones := tensor.Ones[T](input.Shape(), backend).Raw()
-	zeros := tensor.Zeros[T](input.Shape(), backend).Raw()
+	minMask := backend.GreaterEqual(input, minValues)
+	maxMask := backend.LowerEqual(input, maxValues)
+	combinedMask := backend.And(minMask, maxMask)
 
-	// Check if original input is within bounds: min <= input <= max
-	minMask := backend.GreaterEqual(input, minValues) // bool where input >= min
-	maxMask := backend.LowerEqual(input, maxValues)   // bool where input <= max
-	combinedMask := backend.And(minMask, maxMask)     // bool where min <= input <= max
-
-	// Convert bool mask to dtype T for multiplication
-	mask := backend.Where(combinedMask, ones, zeros)
-	maskedGrad := backend.Mul(outputGrad, mask) // grad_output * mask
+	maskNumeric, err := tensor.Cast(combinedMask, input.DType())
+	if err != nil {
+		panic(fmt.Sprintf("clamp: failed to cast mask: %v", err))
+	}
+	maskedGrad := backend.Mul(outputGrad, maskNumeric)
 
 	return maskedGrad
 }

--- a/internal/autodiff/ops/clamp.go
+++ b/internal/autodiff/ops/clamp.go
@@ -35,25 +35,25 @@ func (op *ClampOp) Backward(outputGrad *tensor.RawTensor, backend tensor.Backend
 
 	switch input.DType() {
 	case tensor.Int32:
-		minBound := tensor.CheckScalarDtype[int32](op.minBound)
-		maxBound := tensor.CheckScalarDtype[int32](op.maxBound)
+		minBound := tensor.CheckScalarDType[int32](op.minBound)
+		maxBound := tensor.CheckScalarDType[int32](op.maxBound)
 		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
 		return []*tensor.RawTensor{maskedGrad}
 	case tensor.Int64:
-		minBound := tensor.CheckScalarDtype[int64](op.minBound)
-		maxBound := tensor.CheckScalarDtype[int64](op.maxBound)
+		minBound := tensor.CheckScalarDType[int64](op.minBound)
+		maxBound := tensor.CheckScalarDType[int64](op.maxBound)
 		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
 		return []*tensor.RawTensor{maskedGrad}
 
 	case tensor.Float32:
-		minBound := tensor.CheckScalarDtype[float32](op.minBound)
-		maxBound := tensor.CheckScalarDtype[float32](op.maxBound)
+		minBound := tensor.CheckScalarDType[float32](op.minBound)
+		maxBound := tensor.CheckScalarDType[float32](op.maxBound)
 		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
 		return []*tensor.RawTensor{maskedGrad}
 
 	case tensor.Float64:
-		minBound := tensor.CheckScalarDtype[float64](op.minBound)
-		maxBound := tensor.CheckScalarDtype[float64](op.maxBound)
+		minBound := tensor.CheckScalarDType[float64](op.minBound)
+		maxBound := tensor.CheckScalarDType[float64](op.maxBound)
 		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
 		return []*tensor.RawTensor{maskedGrad}
 	default:

--- a/internal/autodiff/ops/clamp.go
+++ b/internal/autodiff/ops/clamp.go
@@ -32,27 +32,35 @@ func NewClampOp(input *tensor.RawTensor, minBound, maxBound any, output *tensor.
 // grad_input = grad_output * (1 if min <= input <= max, else 0).
 func (op *ClampOp) Backward(outputGrad *tensor.RawTensor, backend tensor.Backend) []*tensor.RawTensor {
 	input := op.input
-	minBound := op.minBound
-	maxBound := op.maxBound
 
 	var maskedGrad *tensor.RawTensor
 
 	switch input.DType() {
 	case tensor.Int32:
-		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(int32), maxBound.(int32), backend)
+		minBound := tensor.CheckScalarDtype[int32](op.minBound)
+		maxBound := tensor.CheckScalarDtype[int32](op.maxBound)
+		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
+		return []*tensor.RawTensor{maskedGrad}
 	case tensor.Int64:
-		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(int64), maxBound.(int64), backend)
+		minBound := tensor.CheckScalarDtype[int64](op.minBound)
+		maxBound := tensor.CheckScalarDtype[int64](op.maxBound)
+		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
+		return []*tensor.RawTensor{maskedGrad}
 
 	case tensor.Float32:
-		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(float32), maxBound.(float32), backend)
+		minBound := tensor.CheckScalarDtype[float32](op.minBound)
+		maxBound := tensor.CheckScalarDtype[float32](op.maxBound)
+		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
+		return []*tensor.RawTensor{maskedGrad}
 
 	case tensor.Float64:
-		maskedGrad = clampBackwardGeneric(outputGrad, input, minBound.(float64), maxBound.(float64), backend)
+		minBound := tensor.CheckScalarDtype[float64](op.minBound)
+		maxBound := tensor.CheckScalarDtype[float64](op.maxBound)
+		maskedGrad := clampBackwardGeneric(outputGrad, input, minBound, maxBound, backend)
+		return []*tensor.RawTensor{maskedGrad}
 	default:
 		panic("clamp: unsupported dtype (only int32/int64/float32/float64 supported)")
 	}
-
-	return []*tensor.RawTensor{maskedGrad}
 }
 
 func clampBackwardGeneric[T int32 | int64 | float32 | float64](outputGrad, input *tensor.RawTensor, minBound, maxBound T, backend tensor.Backend) *tensor.RawTensor {

--- a/internal/autodiff/ops/clamp_test.go
+++ b/internal/autodiff/ops/clamp_test.go
@@ -1,0 +1,506 @@
+package ops
+
+import (
+	"math"
+	"testing"
+
+	"github.com/born-ml/born/internal/backend/cpu"
+	"github.com/born-ml/born/internal/tensor"
+)
+
+const epsilon = 1e-5
+
+// floatAlmostEqual checks if two float64 values are approximately equal within a given epsilon, treating NaNs as equal.
+func floatAlmostEqual(a, b float64) bool {
+	if math.IsNaN(a) {
+		return math.IsNaN(b)
+	}
+	if math.IsNaN(b) {
+		return math.IsNaN(a)
+	}
+	return math.Abs(a-b) <= epsilon
+}
+
+type clampTestCase[T int32 | int64 | float32 | float64] struct {
+	name  string
+	a     []T
+	want  []T
+	shape tensor.Shape
+	min   T
+	max   T
+}
+
+func TestClamp_ForwardInt32(t *testing.T) {
+	backend := cpu.New()
+	tests := []clampTestCase[int32]{
+		{"basic", []int32{-2, -1, 0, 1, 2}, []int32{-1, -1, 0, 1, 1}, tensor.Shape{5}, -1, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := tensor.NewRaw(tt.shape, tensor.Int32, backend.Device())
+			copy(input.AsInt32(), tt.a)
+
+			result := backend.Clamp(input, tt.min, tt.max)
+
+			if !result.Shape().Equal(tt.shape) {
+				t.Errorf("Expected shape %v, got %v", tt.shape, result.Shape())
+			}
+
+			outputData := result.AsInt32()
+			for i, v := range outputData {
+				if v != tt.want[i] {
+					t.Errorf("clamp(%d) = %d, want %d", tt.a[i], v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestClamp_ForwardInt64(t *testing.T) {
+	backend := cpu.New()
+	tests := []clampTestCase[int64]{
+		{"basic", []int64{-2, -1, 0, 1, 2}, []int64{-1, -1, 0, 1, 1}, tensor.Shape{5}, -1, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := tensor.NewRaw(tt.shape, tensor.Int64, backend.Device())
+			copy(input.AsInt64(), tt.a)
+
+			result := backend.Clamp(input, tt.min, tt.max)
+
+			if !result.Shape().Equal(tt.shape) {
+				t.Errorf("Expected shape %v, got %v", tt.shape, result.Shape())
+			}
+
+			outputData := result.AsInt64()
+			for i, v := range outputData {
+				if v != tt.want[i] {
+					t.Errorf("clamp(%d) = %d, want %d", tt.a[i], v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestClamp_ForwardFloat32(t *testing.T) {
+	backend := cpu.New()
+	tests := []clampTestCase[float32]{
+		{"basic", []float32{-2, -1, 0, 1, 2}, []float32{-1, -1, 0, 1, 1}, tensor.Shape{5}, -1, 1},
+		{"edges", []float32{float32(math.Inf(-1)), float32(math.Inf(1)), float32(math.NaN())}, []float32{-1, 1, float32(math.NaN())}, tensor.Shape{3}, float32(-1), float32(1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := tensor.NewRaw(tt.shape, tensor.Float32, backend.Device())
+			copy(input.AsFloat32(), tt.a)
+
+			result := backend.Clamp(input, tt.min, tt.max)
+
+			if !result.Shape().Equal(tt.shape) {
+				t.Errorf("Expected shape %v, got %v", tt.shape, result.Shape())
+			}
+
+			outputData := result.AsFloat32()
+			for i, v := range outputData {
+				if !floatAlmostEqual(float64(v), float64(tt.want[i])) {
+					t.Errorf("clamp(%f) = %f, want %f", tt.a[i], v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestClamp_ForwardFloat64(t *testing.T) {
+	backend := cpu.New()
+	tests := []clampTestCase[float64]{
+		{"basic", []float64{-2, -1, 0, 1, 2}, []float64{-1, -1, 0, 1, 1}, tensor.Shape{5}, -1, 1},
+		{"edges", []float64{math.Inf(-1), math.Inf(1), math.NaN()}, []float64{-1, 1, math.NaN()}, tensor.Shape{3}, -1, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := tensor.NewRaw(tt.shape, tensor.Float64, backend.Device())
+			copy(input.AsFloat64(), tt.a)
+
+			result := backend.Clamp(input, tt.min, tt.max)
+
+			if !result.Shape().Equal(tt.shape) {
+				t.Errorf("Expected shape %v, got %v", tt.shape, result.Shape())
+			}
+
+			outputData := result.AsFloat64()
+			for i, v := range outputData {
+				if !floatAlmostEqual(v, tt.want[i]) {
+					t.Errorf("clamp(%f) = %f, want %f", tt.a[i], v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestClamp_NaNBoundsPanic verifies that NaN bounds cause panics in forward pass.
+func TestClamp_NaNBoundsPanic_Float32(t *testing.T) {
+	backend := cpu.New()
+	input, _ := tensor.NewRaw(tensor.Shape{3}, tensor.Float32, backend.Device())
+	copy(input.AsFloat32(), []float32{-1, 0, 1})
+
+	tests := []struct {
+		name  string
+		min   float32
+		max   float32
+		isMin bool // true if NaN is in min, false if in max
+	}{
+		{"nan_min", float32(math.NaN()), 1, true},
+		{"nan_max", 0, float32(math.NaN()), false},
+		{"both_nan", float32(math.NaN()), float32(math.NaN()), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("Expected panic for NaN bounds, but none occurred")
+				}
+			}()
+			backend.Clamp(input, tt.min, tt.max)
+		})
+	}
+}
+
+func TestClamp_NaNBoundsPanic_Float64(t *testing.T) {
+	backend := cpu.New()
+	input, _ := tensor.NewRaw(tensor.Shape{3}, tensor.Float64, backend.Device())
+	copy(input.AsFloat64(), []float64{-1, 0, 1})
+
+	tests := []struct {
+		name  string
+		min   float64
+		max   float64
+		isMin bool // true if NaN is in min, false if in max
+	}{
+		{"nan_min", math.NaN(), 1, true},
+		{"nan_max", 0, math.NaN(), false},
+		{"both_nan", math.NaN(), math.NaN(), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("Expected panic for NaN bounds, but none occurred")
+				}
+			}()
+			backend.Clamp(input, tt.min, tt.max)
+		})
+	}
+}
+
+func TestClamp_BackwardFloat32(t *testing.T) {
+	backend := cpu.New()
+
+	tests := []struct {
+		name       string
+		input      []float32
+		outputGrad []float32
+		min        float32
+		max        float32
+		want       []float32 // Expected gradient
+	}{
+		{
+			name:       "inside_bounds",
+			input:      []float32{-0.5, 0, 0.5, 1, 1.5},
+			outputGrad: []float32{2, 2, 2, 2, 2},
+			min:        0,
+			max:        1,
+			want:       []float32{0, 2, 2, 2, 0}, // Only values in [0,1] pass gradient
+		},
+		{
+			name:       "below_min",
+			input:      []float32{-2, -1},
+			outputGrad: []float32{3, 3},
+			min:        0,
+			max:        1,
+			want:       []float32{0, 0}, // All below min: no gradient
+		},
+		{
+			name:       "above_max",
+			input:      []float32{1.5, 2},
+			outputGrad: []float32{4, 4},
+			min:        0,
+			max:        1,
+			want:       []float32{0, 0}, // All above max: no gradient
+		},
+		{
+			name:       "at_boundaries",
+			input:      []float32{0, 0.5, 1},
+			outputGrad: []float32{1, 1, 1},
+			min:        0,
+			max:        1,
+			want:       []float32{1, 1, 1}, // At boundaries: gradient passes
+		},
+		{
+			name:       "mixed_values",
+			input:      []float32{-1, 0, 0.5, 1, 2},
+			outputGrad: []float32{2, 2, 2, 2, 2},
+			min:        0,
+			max:        1,
+			want:       []float32{0, 2, 2, 2, 0},
+		},
+		{
+			name:       "nan_input",
+			input:      []float32{float32(math.NaN()), 0, 1, float32(math.NaN())},
+			outputGrad: []float32{1, 1, 1, 1},
+			min:        0,
+			max:        1,
+			want:       []float32{0, 1, 1, 0}, // NaN comparisons return false, so gradient is zero
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := tensor.NewRaw(tensor.Shape{len(tt.input)}, tensor.Float32, backend.Device())
+			copy(input.AsFloat32(), tt.input)
+
+			outputGrad, _ := tensor.NewRaw(tensor.Shape{len(tt.outputGrad)}, tensor.Float32, backend.Device())
+			copy(outputGrad.AsFloat32(), tt.outputGrad)
+
+			// Create clamp operation
+			output := backend.Clamp(input, tt.min, tt.max)
+			op := NewClampOp(input, tt.min, tt.max, output)
+
+			// Compute backward
+			grads := op.Backward(outputGrad, backend)
+			inputGrad := grads[0]
+
+			// Verify shape
+			if !inputGrad.Shape().Equal(tensor.Shape{len(tt.want)}) {
+				t.Errorf("Expected shape %v, got %v", tensor.Shape{len(tt.want)}, inputGrad.Shape())
+			}
+
+			// Verify values
+			gradData := inputGrad.AsFloat32()
+			for i, v := range gradData {
+				if !floatAlmostEqual(float64(v), float64(tt.want[i])) {
+					t.Errorf("grad[%d] = %f, want %f (input=%f, grad_out=%f)", i, v, tt.want[i], tt.input[i], tt.outputGrad[i])
+				}
+			}
+		})
+	}
+}
+
+func TestClamp_BackwardFloat64(t *testing.T) {
+	backend := cpu.New()
+
+	tests := []struct {
+		name       string
+		input      []float64
+		outputGrad []float64
+		min        float64
+		max        float64
+		want       []float64 // Expected gradient
+	}{
+		{
+			name:       "inside_bounds",
+			input:      []float64{-0.5, 0, 0.5, 1, 1.5},
+			outputGrad: []float64{2, 2, 2, 2, 2},
+			min:        0,
+			max:        1,
+			want:       []float64{0, 2, 2, 2, 0},
+		},
+		{
+			name:       "below_min",
+			input:      []float64{-2, -1},
+			outputGrad: []float64{3, 3},
+			min:        0,
+			max:        1,
+			want:       []float64{0, 0},
+		},
+		{
+			name:       "above_max",
+			input:      []float64{1.5, 2},
+			outputGrad: []float64{4, 4},
+			min:        0,
+			max:        1,
+			want:       []float64{0, 0},
+		},
+		{
+			name:       "at_boundaries",
+			input:      []float64{0, 0.5, 1},
+			outputGrad: []float64{1, 1, 1},
+			min:        0,
+			max:        1,
+			want:       []float64{1, 1, 1},
+		},
+		{
+			name:       "negative_bounds",
+			input:      []float64{-2, -1, 0, 1},
+			outputGrad: []float64{1, 1, 1, 1},
+			min:        -1,
+			max:        0,
+			want:       []float64{0, 1, 1, 0},
+		},
+		{
+			name:       "zero_gradient",
+			input:      []float64{-0.5, 0, 0.5, 1, 1.5},
+			outputGrad: []float64{0, 0, 0, 0, 0},
+			min:        0,
+			max:        1,
+			want:       []float64{0, 0, 0, 0, 0},
+		},
+		{
+			name:       "nan_input",
+			input:      []float64{math.NaN(), 0, 1, math.NaN()},
+			outputGrad: []float64{1, 1, 1, 1},
+			min:        0,
+			max:        1,
+			want:       []float64{0, 1, 1, 0}, // NaN comparisons return false, so gradient is zero
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := tensor.NewRaw(tensor.Shape{len(tt.input)}, tensor.Float64, backend.Device())
+			copy(input.AsFloat64(), tt.input)
+
+			outputGrad, _ := tensor.NewRaw(tensor.Shape{len(tt.outputGrad)}, tensor.Float64, backend.Device())
+			copy(outputGrad.AsFloat64(), tt.outputGrad)
+
+			// Create clamp operation
+			output := backend.Clamp(input, tt.min, tt.max)
+			op := NewClampOp(input, tt.min, tt.max, output)
+
+			// Compute backward
+			grads := op.Backward(outputGrad, backend)
+			inputGrad := grads[0]
+
+			// Verify shape
+			if !inputGrad.Shape().Equal(tensor.Shape{len(tt.want)}) {
+				t.Errorf("Expected shape %v, got %v", tensor.Shape{len(tt.want)}, inputGrad.Shape())
+			}
+
+			// Verify values
+			gradData := inputGrad.AsFloat64()
+			for i, v := range gradData {
+				if !floatAlmostEqual(v, tt.want[i]) {
+					t.Errorf("grad[%d] = %f, want %f (input=%f, grad_out=%f)", i, v, tt.want[i], tt.input[i], tt.outputGrad[i])
+				}
+			}
+		})
+	}
+}
+
+// TestClamp_BackwardInt32 tests the backward pass gradient computation for int32.
+func TestClamp_BackwardInt32(t *testing.T) {
+	backend := cpu.New()
+
+	tests := []struct {
+		name       string
+		input      []int32
+		outputGrad []int32
+		min        int32
+		max        int32
+		want       []int32 // Expected gradient
+	}{
+		{
+			name:       "inside_bounds",
+			input:      []int32{-1, 0, 1, 2, 3},
+			outputGrad: []int32{2, 2, 2, 2, 2},
+			min:        0,
+			max:        2,
+			want:       []int32{0, 2, 2, 2, 0},
+		},
+		{
+			name:       "at_boundaries",
+			input:      []int32{0, 1, 2},
+			outputGrad: []int32{5, 5, 5},
+			min:        0,
+			max:        2,
+			want:       []int32{5, 5, 5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := tensor.NewRaw(tensor.Shape{len(tt.input)}, tensor.Int32, backend.Device())
+			copy(input.AsInt32(), tt.input)
+
+			outputGrad, _ := tensor.NewRaw(tensor.Shape{len(tt.outputGrad)}, tensor.Int32, backend.Device())
+			copy(outputGrad.AsInt32(), tt.outputGrad)
+
+			// Create clamp operation
+			output := backend.Clamp(input, tt.min, tt.max)
+			op := NewClampOp(input, tt.min, tt.max, output)
+
+			// Compute backward
+			grads := op.Backward(outputGrad, backend)
+			inputGrad := grads[0]
+
+			// Verify values
+			gradData := inputGrad.AsInt32()
+			for i, v := range gradData {
+				if v != tt.want[i] {
+					t.Errorf("grad[%d] = %d, want %d (input=%d, grad_out=%d)", i, v, tt.want[i], tt.input[i], tt.outputGrad[i])
+				}
+			}
+		})
+	}
+}
+
+// TestClamp_BackwardInt64 tests the backward pass gradient computation for int64.
+func TestClamp_BackwardInt64(t *testing.T) {
+	backend := cpu.New()
+
+	tests := []struct {
+		name       string
+		input      []int64
+		outputGrad []int64
+		min        int64
+		max        int64
+		want       []int64 // Expected gradient
+	}{
+		{
+			name:       "inside_bounds",
+			input:      []int64{-1, 0, 1, 2, 3},
+			outputGrad: []int64{2, 2, 2, 2, 2},
+			min:        0,
+			max:        2,
+			want:       []int64{0, 2, 2, 2, 0},
+		},
+		{
+			name:       "at_boundaries",
+			input:      []int64{0, 1, 2},
+			outputGrad: []int64{5, 5, 5},
+			min:        0,
+			max:        2,
+			want:       []int64{5, 5, 5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := tensor.NewRaw(tensor.Shape{len(tt.input)}, tensor.Int64, backend.Device())
+			copy(input.AsInt64(), tt.input)
+
+			outputGrad, _ := tensor.NewRaw(tensor.Shape{len(tt.outputGrad)}, tensor.Int64, backend.Device())
+			copy(outputGrad.AsInt64(), tt.outputGrad)
+
+			// Create clamp operation
+			output := backend.Clamp(input, tt.min, tt.max)
+			op := NewClampOp(input, tt.min, tt.max, output)
+
+			// Compute backward
+			grads := op.Backward(outputGrad, backend)
+			inputGrad := grads[0]
+
+			// Verify values
+			gradData := inputGrad.AsInt64()
+			for i, v := range gradData {
+				if v != tt.want[i] {
+					t.Errorf("grad[%d] = %d, want %d (input=%d, grad_out=%d)", i, v, tt.want[i], tt.input[i], tt.outputGrad[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/backend/cpu/clamp.go
+++ b/internal/backend/cpu/clamp.go
@@ -20,22 +20,22 @@ func (cpu *CPUBackend) Clamp(input *tensor.RawTensor, minBound, maxBound any) *t
 	// otherwise, perform normal clamp operation
 	switch input.DType() {
 	case tensor.Int32:
-		castedMin := tensor.CheckScalarDtype[int32](minBound)
-		castedMax := tensor.CheckScalarDtype[int32](maxBound)
+		castedMin := tensor.CheckScalarDType[int32](minBound)
+		castedMax := tensor.CheckScalarDType[int32](maxBound)
 		if castedMin > castedMax {
 			return tensor.Full(input.Shape(), castedMax, cpu).Raw()
 		}
 		result = clampGeneric(input, castedMin, castedMax, cpu)
 	case tensor.Int64:
-		castedMin := tensor.CheckScalarDtype[int64](minBound)
-		castedMax := tensor.CheckScalarDtype[int64](maxBound)
+		castedMin := tensor.CheckScalarDType[int64](minBound)
+		castedMax := tensor.CheckScalarDType[int64](maxBound)
 		if castedMin > castedMax {
 			return tensor.Full(input.Shape(), castedMax, cpu).Raw()
 		}
 		result = clampGeneric(input, castedMin, castedMax, cpu)
 	case tensor.Float32:
-		castedMin := tensor.CheckScalarDtype[float32](minBound)
-		castedMax := tensor.CheckScalarDtype[float32](maxBound)
+		castedMin := tensor.CheckScalarDType[float32](minBound)
+		castedMax := tensor.CheckScalarDType[float32](maxBound)
 		checkNaN(castedMin)
 		checkNaN(castedMax)
 		if castedMin > castedMax {
@@ -43,8 +43,8 @@ func (cpu *CPUBackend) Clamp(input *tensor.RawTensor, minBound, maxBound any) *t
 		}
 		result = clampGeneric(input, castedMin, castedMax, cpu)
 	case tensor.Float64:
-		castedMin := tensor.CheckScalarDtype[float64](minBound)
-		castedMax := tensor.CheckScalarDtype[float64](maxBound)
+		castedMin := tensor.CheckScalarDType[float64](minBound)
+		castedMax := tensor.CheckScalarDType[float64](maxBound)
 		checkNaN(castedMin)
 		checkNaN(castedMax)
 		if castedMin > castedMax {

--- a/internal/backend/cpu/clamp.go
+++ b/internal/backend/cpu/clamp.go
@@ -1,6 +1,7 @@
 package cpu
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/born-ml/born/internal/tensor"
@@ -12,36 +13,38 @@ func (cpu *CPUBackend) Clamp(input *tensor.RawTensor, minBound, maxBound any) *t
 		panic("clamp: min and max bounds cannot be nil")
 	}
 
-	if input.DType() == tensor.Float32 {
-		checkNaNBounds[float32](minBound, maxBound)
-	} else if input.DType() == tensor.Float64 {
-		checkNaNBounds[float64](minBound, maxBound)
-	}
-
 	var result *tensor.RawTensor
 	// when minBound > maxBound set all values to maxBound
 	// otherwise, perform normal clamp operation
 	switch input.DType() {
 	case tensor.Int32:
-		if minBound.(int32) > maxBound.(int32) {
-			return tensor.Full(input.Shape(), maxBound.(int32), cpu).Raw()
+		castedMin, castedMax := checkBoundsDtype[int32](minBound, maxBound)
+		if castedMin > castedMax {
+			return tensor.Full(input.Shape(), castedMax, cpu).Raw()
 		}
-		result = clampGeneric(input, minBound.(int32), maxBound.(int32), cpu)
+		result = clampGeneric(input, castedMin, castedMax, cpu)
 	case tensor.Int64:
-		if minBound.(int64) > maxBound.(int64) {
-			return tensor.Full(input.Shape(), maxBound.(int64), cpu).Raw()
+		castedMin, castedMax := checkBoundsDtype[int64](minBound, maxBound)
+		if castedMin > castedMax {
+			return tensor.Full(input.Shape(), castedMax, cpu).Raw()
 		}
-		result = clampGeneric(input, minBound.(int64), maxBound.(int64), cpu)
+		result = clampGeneric(input, castedMin, castedMax, cpu)
 	case tensor.Float32:
-		if minBound.(float32) > maxBound.(float32) {
-			return tensor.Full(input.Shape(), maxBound.(float32), cpu).Raw()
+		castedMin, castedMax := checkBoundsDtype[float32](minBound, maxBound)
+		checkNaN(castedMin)
+		checkNaN(castedMax)
+		if castedMin > castedMax {
+			return tensor.Full(input.Shape(), castedMax, cpu).Raw()
 		}
-		result = clampGeneric(input, minBound.(float32), maxBound.(float32), cpu)
+		result = clampGeneric(input, castedMin, castedMax, cpu)
 	case tensor.Float64:
-		if minBound.(float64) > maxBound.(float64) {
-			return tensor.Full(input.Shape(), maxBound.(float64), cpu).Raw()
+		castedMin, castedMax := checkBoundsDtype[float64](minBound, maxBound)
+		checkNaN(castedMin)
+		checkNaN(castedMax)
+		if castedMin > castedMax {
+			return tensor.Full(input.Shape(), castedMax, cpu).Raw()
 		}
-		result = clampGeneric(input, minBound.(float64), maxBound.(float64), cpu)
+		result = clampGeneric(input, castedMin, castedMax, cpu)
 	default:
 		panic("clamp: unsupported dtype (only int32/int64/float32/float64 supported)")
 	}
@@ -49,9 +52,26 @@ func (cpu *CPUBackend) Clamp(input *tensor.RawTensor, minBound, maxBound any) *t
 	return result
 }
 
-func checkNaNBounds[T float32 | float64](minBound, maxBound any) {
-	if math.IsNaN(float64(minBound.(T))) || math.IsNaN(float64(maxBound.(T))) {
-		panic("clamp: min and max bounds cannot be NaN")
+// checkBoundsDtype checks if the bounds and tensor dtype match.
+//
+// Panics if they do not match.
+func checkBoundsDtype[T int32 | int64 | float32 | float64](minBound, maxBound any) (T, T) {
+	minCasted, ok := minBound.(T)
+	if !ok {
+		panic(fmt.Sprintf("clamp: expected %T min bound, got %T", new(T), minBound))
+	}
+	maxCasted, ok := maxBound.(T)
+	if !ok {
+		panic(fmt.Sprintf("clamp: expected %T max bound, got %T", new(T), maxBound))
+	}
+
+	return minCasted, maxCasted
+}
+
+// checkNaN checks if the value is NaN and panics if it is.
+func checkNaN[T float32 | float64](v T) {
+	if math.IsNaN(float64(v)) {
+		panic("clamp: bounds cannot be NaN")
 	}
 }
 

--- a/internal/backend/cpu/clamp.go
+++ b/internal/backend/cpu/clamp.go
@@ -1,7 +1,6 @@
 package cpu
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/born-ml/born/internal/tensor"
@@ -21,19 +20,22 @@ func (cpu *CPUBackend) Clamp(input *tensor.RawTensor, minBound, maxBound any) *t
 	// otherwise, perform normal clamp operation
 	switch input.DType() {
 	case tensor.Int32:
-		castedMin, castedMax := checkBoundsDtype[int32](minBound, maxBound)
+		castedMin := tensor.CheckScalarDtype[int32](minBound)
+		castedMax := tensor.CheckScalarDtype[int32](maxBound)
 		if castedMin > castedMax {
 			return tensor.Full(input.Shape(), castedMax, cpu).Raw()
 		}
 		result = clampGeneric(input, castedMin, castedMax, cpu)
 	case tensor.Int64:
-		castedMin, castedMax := checkBoundsDtype[int64](minBound, maxBound)
+		castedMin := tensor.CheckScalarDtype[int64](minBound)
+		castedMax := tensor.CheckScalarDtype[int64](maxBound)
 		if castedMin > castedMax {
 			return tensor.Full(input.Shape(), castedMax, cpu).Raw()
 		}
 		result = clampGeneric(input, castedMin, castedMax, cpu)
 	case tensor.Float32:
-		castedMin, castedMax := checkBoundsDtype[float32](minBound, maxBound)
+		castedMin := tensor.CheckScalarDtype[float32](minBound)
+		castedMax := tensor.CheckScalarDtype[float32](maxBound)
 		checkNaN(castedMin)
 		checkNaN(castedMax)
 		if castedMin > castedMax {
@@ -41,7 +43,8 @@ func (cpu *CPUBackend) Clamp(input *tensor.RawTensor, minBound, maxBound any) *t
 		}
 		result = clampGeneric(input, castedMin, castedMax, cpu)
 	case tensor.Float64:
-		castedMin, castedMax := checkBoundsDtype[float64](minBound, maxBound)
+		castedMin := tensor.CheckScalarDtype[float64](minBound)
+		castedMax := tensor.CheckScalarDtype[float64](maxBound)
 		checkNaN(castedMin)
 		checkNaN(castedMax)
 		if castedMin > castedMax {
@@ -53,22 +56,6 @@ func (cpu *CPUBackend) Clamp(input *tensor.RawTensor, minBound, maxBound any) *t
 	}
 
 	return result
-}
-
-// checkBoundsDtype checks if the bounds and tensor dtype match.
-//
-// Panics if they do not match.
-func checkBoundsDtype[T int32 | int64 | float32 | float64](minBound, maxBound any) (T, T) {
-	minCasted, ok := minBound.(T)
-	if !ok {
-		panic(fmt.Sprintf("clamp: expected %T min bound, got %T", new(T), minBound))
-	}
-	maxCasted, ok := maxBound.(T)
-	if !ok {
-		panic(fmt.Sprintf("clamp: expected %T max bound, got %T", new(T), maxBound))
-	}
-
-	return minCasted, maxCasted
 }
 
 // checkNaN checks if the value is NaN and panics if it is.

--- a/internal/backend/cpu/clamp.go
+++ b/internal/backend/cpu/clamp.go
@@ -8,6 +8,9 @@ import (
 )
 
 // Clamp restricts tensor values element-wise to [minBound, maxBound].
+// If minBound > maxBound, all values are set to maxBound.
+// Supported dtypes: int32, int64, float32, float64.
+// Panics if bounds are nil, if bounds and tensor dtype do not match, or if bounds are NaN (for floats).
 func (cpu *CPUBackend) Clamp(input *tensor.RawTensor, minBound, maxBound any) *tensor.RawTensor {
 	if minBound == nil || maxBound == nil {
 		panic("clamp: min and max bounds cannot be nil")

--- a/internal/backend/cpu/clamp.go
+++ b/internal/backend/cpu/clamp.go
@@ -1,0 +1,72 @@
+package cpu
+
+import (
+	"math"
+
+	"github.com/born-ml/born/internal/tensor"
+)
+
+// Clamp restricts tensor values element-wise to [minBound, maxBound].
+func (cpu *CPUBackend) Clamp(input *tensor.RawTensor, minBound, maxBound any) *tensor.RawTensor {
+	if minBound == nil || maxBound == nil {
+		panic("clamp: min and max bounds cannot be nil")
+	}
+
+	if input.DType() == tensor.Float32 {
+		checkNaNBounds[float32](minBound, maxBound)
+	} else if input.DType() == tensor.Float64 {
+		checkNaNBounds[float64](minBound, maxBound)
+	}
+
+	var result *tensor.RawTensor
+	// when minBound > maxBound set all values to maxBound
+	// otherwise, perform normal clamp operation
+	switch input.DType() {
+	case tensor.Int32:
+		if minBound.(int32) > maxBound.(int32) {
+			return tensor.Full(input.Shape(), maxBound.(int32), cpu).Raw()
+		}
+		result = clampGeneric(input, minBound.(int32), maxBound.(int32), cpu)
+	case tensor.Int64:
+		if minBound.(int64) > maxBound.(int64) {
+			return tensor.Full(input.Shape(), maxBound.(int64), cpu).Raw()
+		}
+		result = clampGeneric(input, minBound.(int64), maxBound.(int64), cpu)
+	case tensor.Float32:
+		if minBound.(float32) > maxBound.(float32) {
+			return tensor.Full(input.Shape(), maxBound.(float32), cpu).Raw()
+		}
+		result = clampGeneric(input, minBound.(float32), maxBound.(float32), cpu)
+	case tensor.Float64:
+		if minBound.(float64) > maxBound.(float64) {
+			return tensor.Full(input.Shape(), maxBound.(float64), cpu).Raw()
+		}
+		result = clampGeneric(input, minBound.(float64), maxBound.(float64), cpu)
+	default:
+		panic("clamp: unsupported dtype (only int32/int64/float32/float64 supported)")
+	}
+
+	return result
+}
+
+func checkNaNBounds[T float32 | float64](minBound, maxBound any) {
+	if math.IsNaN(float64(minBound.(T))) || math.IsNaN(float64(maxBound.(T))) {
+		panic("clamp: min and max bounds cannot be NaN")
+	}
+}
+
+// clampGeneric performs the clamp operation for a specific data type T.
+func clampGeneric[T int32 | int64 | float32 | float64](input *tensor.RawTensor, minBound, maxBound T, cpu *CPUBackend) *tensor.RawTensor {
+	minValues := tensor.Full(input.Shape(), minBound, cpu).Raw()
+	maxValues := tensor.Full(input.Shape(), maxBound, cpu).Raw()
+
+	// Clamp to min: select max(input, minValues)
+	minMask := cpu.LowerEqual(input, minValues) // 1 where input <= min, else 0
+	clampedMin := cpu.Where(minMask, minValues, input)
+
+	// Clamp to max: select min(clampedMin, maxValues)
+	maxMask := cpu.GreaterEqual(clampedMin, maxValues) // 1 where clampedMin >= max, else 0
+	clamped := cpu.Where(maxMask, maxValues, clampedMin)
+
+	return clamped
+}

--- a/internal/backend/webgpu/clamp_test.go
+++ b/internal/backend/webgpu/clamp_test.go
@@ -1,0 +1,265 @@
+//go:build windows
+
+package webgpu
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/born-ml/born/internal/tensor"
+)
+
+func TestClamp_Float32(t *testing.T) {
+	if !IsAvailable() {
+		t.Skip("WebGPU not available")
+	}
+
+	backend, err := New()
+	if err != nil {
+		t.Fatalf("failed to create backend: %v", err)
+	}
+	defer backend.Release()
+
+	tests := []struct {
+		name     string
+		input    []float32
+		shape    tensor.Shape
+		min      float32
+		max      float32
+		expected []float32
+	}{
+		{
+			name:     "basic",
+			input:    []float32{-2, -1, 0, 1, 2},
+			shape:    tensor.Shape{5},
+			min:      -1,
+			max:      1,
+			expected: []float32{-1, -1, 0, 1, 1},
+		},
+		{
+			name:     "all_below_min",
+			input:    []float32{-5, -3, -1},
+			shape:    tensor.Shape{3},
+			min:      0,
+			max:      1,
+			expected: []float32{0, 0, 0},
+		},
+		{
+			name:     "all_above_max",
+			input:    []float32{2, 3, 5},
+			shape:    tensor.Shape{3},
+			min:      0,
+			max:      1,
+			expected: []float32{1, 1, 1},
+		},
+		{
+			name:     "at_boundaries",
+			input:    []float32{-1, 0, 0.5, 1, 2},
+			shape:    tensor.Shape{5},
+			min:      0,
+			max:      1,
+			expected: []float32{0, 0, 0.5, 1, 1},
+		},
+		{
+			name:     "2d_tensor",
+			input:    []float32{-2, -1, 0, 1, 2, 3},
+			shape:    tensor.Shape{2, 3},
+			min:      0,
+			max:      2,
+			expected: []float32{0, 0, 0, 1, 2, 2},
+		},
+		{
+			name:     "negative_bounds",
+			input:    []float32{-3, -2, -1, 0, 1},
+			shape:    tensor.Shape{5},
+			min:      -2,
+			max:      0,
+			expected: []float32{-2, -2, -1, 0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, err := tensor.NewRaw(tt.shape, tensor.Float32, tensor.WebGPU)
+			if err != nil {
+				t.Fatalf("failed to create tensor: %v", err)
+			}
+
+			byteData := input.Data()
+			for i, v := range tt.input {
+				bits := math.Float32bits(v)
+				byteData[i*4+0] = byte(bits)
+				byteData[i*4+1] = byte(bits >> 8)
+				byteData[i*4+2] = byte(bits >> 16)
+				byteData[i*4+3] = byte(bits >> 24)
+			}
+
+			result := backend.Clamp(input, tt.min, tt.max)
+
+			resultData := result.Data()
+			actual := make([]float32, len(tt.expected))
+			for i := range actual {
+				bits := uint32(resultData[i*4+0]) |
+					uint32(resultData[i*4+1])<<8 |
+					uint32(resultData[i*4+2])<<16 |
+					uint32(resultData[i*4+3])<<24
+				actual[i] = math.Float32frombits(bits)
+			}
+
+			if !compareSlices(t, tt.expected, actual, 1e-5) {
+				t.Errorf("Clamp failed: expected %v, got %v", tt.expected, actual)
+			}
+
+			if !result.Shape().Equal(tt.shape) {
+				t.Errorf("Shape mismatch: expected %v, got %v", tt.shape, result.Shape())
+			}
+		})
+	}
+}
+
+func TestClamp_Int32(t *testing.T) {
+	if !IsAvailable() {
+		t.Skip("WebGPU not available")
+	}
+
+	backend, err := New()
+	if err != nil {
+		t.Fatalf("failed to create backend: %v", err)
+	}
+	defer backend.Release()
+
+	tests := []struct {
+		name     string
+		input    []int32
+		shape    tensor.Shape
+		min      int32
+		max      int32
+		expected []int32
+	}{
+		{
+			name:     "basic",
+			input:    []int32{-2, -1, 0, 1, 2},
+			shape:    tensor.Shape{5},
+			min:      -1,
+			max:      1,
+			expected: []int32{-1, -1, 0, 1, 1},
+		},
+		{
+			name:     "all_below_min",
+			input:    []int32{-5, -3, -1},
+			shape:    tensor.Shape{3},
+			min:      0,
+			max:      1,
+			expected: []int32{0, 0, 0},
+		},
+		{
+			name:     "all_above_max",
+			input:    []int32{2, 3, 5},
+			shape:    tensor.Shape{3},
+			min:      0,
+			max:      1,
+			expected: []int32{1, 1, 1},
+		},
+		{
+			name:     "2d_tensor",
+			input:    []int32{-2, -1, 0, 1, 2, 3},
+			shape:    tensor.Shape{2, 3},
+			min:      0,
+			max:      2,
+			expected: []int32{0, 0, 0, 1, 2, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, err := tensor.NewRaw(tt.shape, tensor.Int32, tensor.WebGPU)
+			if err != nil {
+				t.Fatalf("failed to create tensor: %v", err)
+			}
+
+			byteData := input.Data()
+			for i, v := range tt.input {
+				binary.LittleEndian.PutUint32(byteData[i*4:i*4+4], uint32(v))
+			}
+
+			result := backend.Clamp(input, tt.min, tt.max)
+
+			resultData := result.Data()
+			actual := make([]int32, len(tt.expected))
+			for i := range actual {
+				actual[i] = int32(binary.LittleEndian.Uint32(resultData[i*4 : i*4+4]))
+			}
+
+			for i, v := range actual {
+				if v != tt.expected[i] {
+					t.Errorf("Clamp[%d] = %d, want %d", i, v, tt.expected[i])
+				}
+			}
+
+			if !result.Shape().Equal(tt.shape) {
+				t.Errorf("Shape mismatch: expected %v, got %v", tt.shape, result.Shape())
+			}
+		})
+	}
+}
+
+func TestClamp_LargeTensor(t *testing.T) {
+	if !IsAvailable() {
+		t.Skip("WebGPU not available")
+	}
+
+	backend, err := New()
+	if err != nil {
+		t.Fatalf("failed to create backend: %v", err)
+	}
+	defer backend.Release()
+
+	size := 1024
+	inputData := make([]float32, size)
+	expected := make([]float32, size)
+
+	minVal := float32(100)
+	maxVal := float32(500)
+
+	for i := 0; i < size; i++ {
+		inputData[i] = float32(i - 200) // Range: -200 to 823
+		if inputData[i] < minVal {
+			expected[i] = minVal
+		} else if inputData[i] > maxVal {
+			expected[i] = maxVal
+		} else {
+			expected[i] = inputData[i]
+		}
+	}
+
+	input, err := tensor.NewRaw(tensor.Shape{size}, tensor.Float32, tensor.WebGPU)
+	if err != nil {
+		t.Fatalf("failed to create tensor: %v", err)
+	}
+
+	byteData := input.Data()
+	for i, v := range inputData {
+		bits := math.Float32bits(v)
+		byteData[i*4+0] = byte(bits)
+		byteData[i*4+1] = byte(bits >> 8)
+		byteData[i*4+2] = byte(bits >> 16)
+		byteData[i*4+3] = byte(bits >> 24)
+	}
+
+	result := backend.Clamp(input, minVal, maxVal)
+
+	resultData := result.Data()
+	actual := make([]float32, size)
+	for i := range actual {
+		bits := uint32(resultData[i*4+0]) |
+			uint32(resultData[i*4+1])<<8 |
+			uint32(resultData[i*4+2])<<16 |
+			uint32(resultData[i*4+3])<<24
+		actual[i] = math.Float32frombits(bits)
+	}
+
+	if !compareSlices(t, expected, actual, 1e-5) {
+		t.Errorf("Large Clamp failed")
+	}
+}

--- a/internal/backend/webgpu/clamp_test.go
+++ b/internal/backend/webgpu/clamp_test.go
@@ -3,12 +3,58 @@
 package webgpu
 
 import (
-	"encoding/binary"
 	"math"
 	"testing"
 
 	"github.com/born-ml/born/internal/tensor"
 )
+
+func runClampTest(t *testing.T, backend *Backend, name string, input, expected []float32, shape tensor.Shape, minValue, maxValue float32) {
+	t.Run(name, func(t *testing.T) {
+		inputTensor := createTensor(t, shape, input)
+		byteData := inputTensor.Data()
+		for i, v := range input {
+			bits := math.Float32bits(v)
+			byteData[i*4+0] = byte(bits)
+			byteData[i*4+1] = byte(bits >> 8)
+			byteData[i*4+2] = byte(bits >> 16)
+			byteData[i*4+3] = byte(bits >> 24)
+		}
+
+		result := backend.Clamp(inputTensor, minValue, maxValue)
+
+		resultData := result.Data()
+		actual := make([]float32, len(expected))
+		for i := range actual {
+			bits := uint32(resultData[i*4+0]) |
+				uint32(resultData[i*4+1])<<8 |
+				uint32(resultData[i*4+2])<<16 |
+				uint32(resultData[i*4+3])<<24
+			actual[i] = math.Float32frombits(bits)
+		}
+		if !compareSlices(t, expected, actual, 1e-5) {
+			t.Errorf("Clamp failed: expected %v, got %v", expected, actual)
+		}
+
+		if !result.Shape().Equal(shape) {
+			t.Errorf("Shape mismatch: expected %v, got %v", shape, result.Shape())
+		}
+	})
+}
+func runClampTestInt32(t *testing.T, backend *Backend, name string, input, expected []int32, shape tensor.Shape, minValue, maxValue int32) {
+	t.Run(name, func(t *testing.T) {
+		inputTensor := createInt32Tensor(t, shape, input)
+		result := backend.Clamp(inputTensor, minValue, maxValue)
+		actual := extractInt32Data(t, result)
+
+		if !compareInt32Slices(t, expected, actual) {
+			t.Errorf("Clamp failed: expected %v, got %v", expected, actual)
+		}
+		if !result.Shape().Equal(shape) {
+			t.Errorf("Shape mismatch: expected %v, got %v", shape, result.Shape())
+		}
+	})
+}
 
 func TestClamp_Float32(t *testing.T) {
 	if !computeAvailable {
@@ -80,41 +126,7 @@ func TestClamp_Float32(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			input, err := tensor.NewRaw(tt.shape, tensor.Float32, tensor.WebGPU)
-			if err != nil {
-				t.Fatalf("failed to create tensor: %v", err)
-			}
-
-			byteData := input.Data()
-			for i, v := range tt.input {
-				bits := math.Float32bits(v)
-				byteData[i*4+0] = byte(bits)
-				byteData[i*4+1] = byte(bits >> 8)
-				byteData[i*4+2] = byte(bits >> 16)
-				byteData[i*4+3] = byte(bits >> 24)
-			}
-
-			result := backend.Clamp(input, tt.min, tt.max)
-
-			resultData := result.Data()
-			actual := make([]float32, len(tt.expected))
-			for i := range actual {
-				bits := uint32(resultData[i*4+0]) |
-					uint32(resultData[i*4+1])<<8 |
-					uint32(resultData[i*4+2])<<16 |
-					uint32(resultData[i*4+3])<<24
-				actual[i] = math.Float32frombits(bits)
-			}
-
-			if !compareSlices(t, tt.expected, actual, 1e-5) {
-				t.Errorf("Clamp failed: expected %v, got %v", tt.expected, actual)
-			}
-
-			if !result.Shape().Equal(tt.shape) {
-				t.Errorf("Shape mismatch: expected %v, got %v", tt.shape, result.Shape())
-			}
-		})
+		runClampTest(t, backend, tt.name, tt.input, tt.expected, tt.shape, tt.min, tt.max)
 	}
 }
 
@@ -172,35 +184,7 @@ func TestClamp_Int32(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			input, err := tensor.NewRaw(tt.shape, tensor.Int32, tensor.WebGPU)
-			if err != nil {
-				t.Fatalf("failed to create tensor: %v", err)
-			}
-
-			byteData := input.Data()
-			for i, v := range tt.input {
-				binary.LittleEndian.PutUint32(byteData[i*4:i*4+4], uint32(v))
-			}
-
-			result := backend.Clamp(input, tt.min, tt.max)
-
-			resultData := result.Data()
-			actual := make([]int32, len(tt.expected))
-			for i := range actual {
-				actual[i] = int32(binary.LittleEndian.Uint32(resultData[i*4 : i*4+4]))
-			}
-
-			for i, v := range actual {
-				if v != tt.expected[i] {
-					t.Errorf("Clamp[%d] = %d, want %d", i, v, tt.expected[i])
-				}
-			}
-
-			if !result.Shape().Equal(tt.shape) {
-				t.Errorf("Shape mismatch: expected %v, got %v", tt.shape, result.Shape())
-			}
-		})
+		runClampTestInt32(t, backend, tt.name, tt.input, tt.expected, tt.shape, tt.min, tt.max)
 	}
 }
 
@@ -224,11 +208,12 @@ func TestClamp_LargeTensor(t *testing.T) {
 
 	for i := 0; i < size; i++ {
 		inputData[i] = float32(i - 200) // Range: -200 to 823
-		if inputData[i] < minVal {
+		switch {
+		case inputData[i] < minVal:
 			expected[i] = minVal
-		} else if inputData[i] > maxVal {
+		case inputData[i] > maxVal:
 			expected[i] = maxVal
-		} else {
+		default:
 			expected[i] = inputData[i]
 		}
 	}

--- a/internal/backend/webgpu/clamp_test.go
+++ b/internal/backend/webgpu/clamp_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestClamp_Float32(t *testing.T) {
-	if !IsAvailable() {
+	if !computeAvailable {
 		t.Skip("WebGPU not available")
 	}
 
@@ -119,7 +119,7 @@ func TestClamp_Float32(t *testing.T) {
 }
 
 func TestClamp_Int32(t *testing.T) {
-	if !IsAvailable() {
+	if !computeAvailable {
 		t.Skip("WebGPU not available")
 	}
 
@@ -205,7 +205,7 @@ func TestClamp_Int32(t *testing.T) {
 }
 
 func TestClamp_LargeTensor(t *testing.T) {
-	if !IsAvailable() {
+	if !computeAvailable {
 		t.Skip("WebGPU not available")
 	}
 

--- a/internal/backend/webgpu/compute.go
+++ b/internal/backend/webgpu/compute.go
@@ -756,6 +756,69 @@ func (b *Backend) runTranspose(input *tensor.RawTensor) (*tensor.RawTensor, erro
 	return result, nil
 }
 
+// runClamp executes element-wise clamping: clamp(x, min, max) on GPU.
+// Supports float32 and int32 dtypes.
+func (b *Backend) runClamp(input *tensor.RawTensor, minBound, maxBound any) (*tensor.RawTensor, error) {
+	dtype := input.DType()
+	if dtype != tensor.Float32 && dtype != tensor.Int32 {
+		return nil, fmt.Errorf("webgpu: Clamp: only float32 and int32 are supported, got %s", dtype)
+	}
+
+	numElements := input.NumElements()
+
+	shaderName, shaderCode := selectBinaryShader(dtype, "clamp", clampShader, clampShaderInt32)
+
+	shader := b.compileShader(shaderName, shaderCode)
+	pipeline := b.getOrCreatePipeline(shaderName, shader, bglUnary)
+
+	bufferInput := b.createBuffer(input.Data(), gputypes.BufferUsageStorage|gputypes.BufferUsageCopySrc)
+	defer bufferInput.Release()
+
+	resultSize := uint64(input.ByteSize()) //nolint:gosec // G115: integer overflow conversion int -> uint64
+	bufferResult, err := b.device.CreateBuffer(&wgpu.BufferDescriptor{
+		Usage: gputypes.BufferUsageStorage | gputypes.BufferUsageCopySrc | gputypes.BufferUsageCopyDst,
+		Size:  resultSize,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("webgpu: create result buffer: %w", err)
+	}
+	defer bufferResult.Release()
+
+	params := make([]byte, 16)                                      // 16-byte aligned: size + min + max
+	binary.LittleEndian.PutUint32(params[0:4], uint32(numElements)) //nolint:gosec // G115: integer overflow conversion int -> uint32
+
+	if dtype == tensor.Float32 {
+		minVal := minBound.(float32)
+		maxVal := maxBound.(float32)
+		binary.LittleEndian.PutUint32(params[4:8], math.Float32bits(minVal))
+		binary.LittleEndian.PutUint32(params[8:12], math.Float32bits(maxVal))
+	} else {
+		minVal := minBound.(int32)
+		maxVal := maxBound.(int32)
+		binary.LittleEndian.PutUint32(params[4:8], uint32(minVal))  //nolint:gosec // G115: safe, int32 fits in uint32
+		binary.LittleEndian.PutUint32(params[8:12], uint32(maxVal)) //nolint:gosec // G115: safe, int32 fits in uint32
+	}
+	bufferParams := b.createUniformBuffer(params)
+	defer bufferParams.Release()
+
+	bg := b.createBindGroupFromBuffers(pipeline.layout, []bindGroupBuffer{
+		bufBinding(bufferInput, resultSize),
+		bufBinding(bufferResult, resultSize),
+		bufBinding(bufferParams, 16),
+	})
+	defer bg.Release()
+
+	workgroups := uint32((numElements + workgroupSize - 1) / workgroupSize) //nolint:gosec // G115: integer overflow conversion int -> uint32
+	resultData := b.execComputeAndRead(pipeline.pipeline, bg, workgroups, 1, 1, bufferResult, resultSize)
+
+	result, err := tensor.NewRaw(input.Shape(), dtype, tensor.WebGPU)
+	if err != nil {
+		return nil, err
+	}
+	copy(result.Data(), resultData)
+	return result, nil
+}
+
 // runScalarOp executes a scalar operation (MulScalar, AddScalar, etc.) on GPU.
 // The shader params contain both size (u32) and scalar value (f32).
 func (b *Backend) runScalarOp(input *tensor.RawTensor, scalar float32, shaderName, shaderCode string) (*tensor.RawTensor, error) {

--- a/internal/backend/webgpu/gpu_ops.go
+++ b/internal/backend/webgpu/gpu_ops.go
@@ -278,9 +278,9 @@ func (b *Backend) AbsGPU(t *GPUTensor) *GPUTensor {
 	return b.runUnaryOpGPU(t, "abs", absShader)
 }
 
-// ClampGPU applies clamp activation on GPU: clamp(x, min, max).
+// ClampGPU applies clamp activation on GPU: clamp(x, minValue, maxValue).
 // Data stays on GPU - no CPU transfer occurs.
-func (b *Backend) ClampGPU(t *GPUTensor, min, max any) *GPUTensor {
+func (b *Backend) ClampGPU(t *GPUTensor, minValue, maxValue any) *GPUTensor {
 	// Validate dtype
 	if t.dtype != tensor.Float32 && t.dtype != tensor.Int32 {
 		panic(fmt.Sprintf("webgpu: ClampGPU: only float32 and int32 supported, got %s", t.dtype))
@@ -311,13 +311,13 @@ func (b *Backend) ClampGPU(t *GPUTensor, min, max any) *GPUTensor {
 	binary.LittleEndian.PutUint32(params[0:4], uint32(numElements)) //nolint:gosec // G115: integer overflow conversion int -> uint32
 
 	if t.dtype == tensor.Float32 {
-		minVal := min.(float32)
-		maxVal := max.(float32)
+		minVal := tensor.CheckScalarDType[float32](minValue)
+		maxVal := tensor.CheckScalarDType[float32](maxValue)
 		binary.LittleEndian.PutUint32(params[4:8], math.Float32bits(minVal))
 		binary.LittleEndian.PutUint32(params[8:12], math.Float32bits(maxVal))
 	} else {
-		minVal := min.(int32)
-		maxVal := max.(int32)
+		minVal := tensor.CheckScalarDType[int32](minValue)
+		maxVal := tensor.CheckScalarDType[int32](maxValue)
 		binary.LittleEndian.PutUint32(params[4:8], uint32(minVal))  //nolint:gosec
 		binary.LittleEndian.PutUint32(params[8:12], uint32(maxVal)) //nolint:gosec
 	}

--- a/internal/backend/webgpu/gpu_ops.go
+++ b/internal/backend/webgpu/gpu_ops.go
@@ -6,6 +6,7 @@ package webgpu
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 
 	"github.com/born-ml/born/internal/tensor"
 	"github.com/gogpu/gputypes"
@@ -275,6 +276,74 @@ func (b *Backend) SignGPU(t *GPUTensor) *GPUTensor {
 // Data stays on GPU - no CPU transfer occurs.
 func (b *Backend) AbsGPU(t *GPUTensor) *GPUTensor {
 	return b.runUnaryOpGPU(t, "abs", absShader)
+}
+
+// ClampGPU applies clamp activation on GPU: clamp(x, min, max).
+// Data stays on GPU - no CPU transfer occurs.
+func (b *Backend) ClampGPU(t *GPUTensor, min, max any) *GPUTensor {
+	// Validate dtype
+	if t.dtype != tensor.Float32 && t.dtype != tensor.Int32 {
+		panic(fmt.Sprintf("webgpu: ClampGPU: only float32 and int32 supported, got %s", t.dtype))
+	}
+
+	shaderName, shaderCode := selectBinaryShader(t.dtype, "clamp", clampShader, clampShaderInt32)
+
+	numElements := t.NumElements()
+
+	// Compile shader
+	shader := b.compileShader(shaderName, shaderCode)
+
+	// Get or create pipeline
+	pipeline := b.getOrCreatePipeline(shaderName, shader, bglBinary)
+
+	// Create output buffer (stays on GPU!)
+	resultSize := t.ByteSize()
+	bufferResult, err := b.device.CreateBuffer(&wgpu.BufferDescriptor{
+		Usage: gputypes.BufferUsageStorage | gputypes.BufferUsageCopySrc | gputypes.BufferUsageCopyDst,
+		Size:  resultSize,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("webgpu: ClampGPU: failed to create result buffer: %v", err))
+	}
+
+	// Create uniform buffer for params (size: u32, min: f32/i32, max: f32/i32)
+	params := make([]byte, 16)                                      // 16-byte aligned
+	binary.LittleEndian.PutUint32(params[0:4], uint32(numElements)) //nolint:gosec // G115: integer overflow conversion int -> uint32
+
+	if t.dtype == tensor.Float32 {
+		minVal := min.(float32)
+		maxVal := max.(float32)
+		binary.LittleEndian.PutUint32(params[4:8], math.Float32bits(minVal))
+		binary.LittleEndian.PutUint32(params[8:12], math.Float32bits(maxVal))
+	} else {
+		minVal := min.(int32)
+		maxVal := max.(int32)
+		binary.LittleEndian.PutUint32(params[4:8], uint32(minVal))  //nolint:gosec
+		binary.LittleEndian.PutUint32(params[8:12], uint32(maxVal)) //nolint:gosec
+	}
+
+	bufferParams := b.createUniformBuffer(params)
+	defer bufferParams.Release()
+
+	// Get bind group layout and create bind group
+	bg := b.createBindGroupFromBuffers(pipeline.layout, []bindGroupBuffer{
+		bufBinding(t.buffer, t.bufferSize),
+		bufBinding(bufferResult, resultSize),
+		bufBinding(bufferParams, 16),
+	})
+	defer bg.Release()
+
+	workgroups := uint32((numElements + workgroupSize - 1) / workgroupSize) //nolint:gosec // G115: integer overflow conversion int -> uint32
+	b.execComputePass(pipeline.pipeline, bg, workgroups, 1, 1)
+
+	// Return GPUTensor (NO readBuffer!)
+	return &GPUTensor{
+		buffer:     bufferResult,
+		bufferSize: resultSize,
+		shape:      t.shape,
+		dtype:      t.dtype,
+		backend:    b,
+	}
 }
 
 // SoftmaxGPU applies softmax activation along the specified dimension.

--- a/internal/backend/webgpu/lazy_compute.go
+++ b/internal/backend/webgpu/lazy_compute.go
@@ -1424,16 +1424,28 @@ func (b *Backend) runClampLazy(input *tensor.RawTensor, minBound, maxBound any) 
 	shaderName, shaderCode := selectBinaryShader(dtype, "clamp", clampShader, clampShaderInt32)
 
 	shader := b.compileShader(shaderName, shaderCode)
-	pipeline := b.getOrCreatePipeline(shaderName, shader)
+	pipeline := b.getOrCreatePipeline(shaderName, shader, bglUnary)
 
 	bufferInput := b.createBufferFromTensor(input)
 	defer bufferInput.Release()
 
 	resultSize := uint64(input.ByteSize()) //nolint:gosec // G115: integer overflow conversion int -> uint64
-	bufferResult := b.device.CreateBuffer(&wgpu.BufferDescriptor{
+	bufferResult, err := b.device.CreateBuffer(&wgpu.BufferDescriptor{
 		Usage: gputypes.BufferUsageStorage | gputypes.BufferUsageCopySrc | gputypes.BufferUsageCopyDst,
 		Size:  resultSize,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("runClampLazy: create result buffer: %w", err)
+	}
+	defer bufferResult.Release()
+
+	stagingBuf, err := b.device.CreateBuffer(&wgpu.BufferDescriptor{
+		Usage: gputypes.BufferUsageMapRead | gputypes.BufferUsageCopyDst | gputypes.BufferUsageCopySrc,
+		Size:  resultSize,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("runBinaryOpLazy: create staging buffer: %w", err)
+	}
 
 	params := make([]byte, 16)
 	putUint32LE(params[0:4], uint32(numElements))
@@ -1448,26 +1460,32 @@ func (b *Backend) runClampLazy(input *tensor.RawTensor, minBound, maxBound any) 
 	bufferParams := b.createUniformBuffer(params)
 	defer bufferParams.Release()
 
-	bindGroupLayout := pipeline.GetBindGroupLayout(0)
-	bindGroup := b.device.CreateBindGroupSimple(bindGroupLayout, []wgpu.BindGroupEntry{
-		wgpu.BufferBindingEntry(0, bufferInput, 0, resultSize),
-		wgpu.BufferBindingEntry(1, bufferResult, 0, resultSize),
-		wgpu.BufferBindingEntry(2, bufferParams, 0, 16),
+	bg := b.createBindGroupFromBuffers(pipeline.layout, []bindGroupBuffer{
+		bufBinding(bufferInput, resultSize),
+		bufBinding(bufferResult, resultSize),
+		bufBinding(bufferParams, 16),
 	})
-	defer bindGroup.Release()
+	defer bg.Release()
 
-	encoder := b.device.CreateCommandEncoder(nil)
-	computePass := encoder.BeginComputePass(nil)
-	computePass.SetPipeline(pipeline)
-	computePass.SetBindGroup(0, bindGroup, nil)
+	encoder, encErr := b.device.CreateCommandEncoder(nil)
+	if encErr != nil {
+		stagingBuf.Release()
+		return nil, fmt.Errorf("runClampLazy: create command encoder: %w", encErr)
+	}
+	computePass, cpErr := encoder.BeginComputePass(nil)
+	if cpErr != nil {
+		return nil, fmt.Errorf("runClampLazy: begin compute pass: %w", cpErr)
+	}
+	computePass.SetPipeline(pipeline.pipeline)
+	computePass.SetBindGroup(0, bg, nil)
 	workgroups := uint32((numElements + workgroupSize - 1) / workgroupSize) //nolint:gosec // G115: integer overflow conversion int -> uint32
-	computePass.DispatchWorkgroups(workgroups, 1, 1)
-	computePass.End()
+	computePass.Dispatch(workgroups, 1, 1)
+	if endErr := computePass.End(); endErr != nil {
+		stagingBuf.Release()
+		panic(fmt.Sprintf("webgpu: compute pass end error: %v", endErr))
+	}
 
-	cmdBuffer := encoder.Finish(nil)
-	b.queueCommand(cmdBuffer)
-
-	return b.createLazyResult(bufferResult, resultSize, input.Shape(), dtype)
+	return b.finishAndSubmitLazy(encoder, bufferResult, stagingBuf, resultSize, input.Shape(), dtype, "runClampLazy")
 }
 
 // putInt32LE writes an int32 to a byte slice in little-endian order.

--- a/internal/backend/webgpu/lazy_compute.go
+++ b/internal/backend/webgpu/lazy_compute.go
@@ -1448,7 +1448,7 @@ func (b *Backend) runClampLazy(input *tensor.RawTensor, minBound, maxBound any) 
 	}
 
 	params := make([]byte, 16)
-	putUint32LE(params[0:4], uint32(numElements))
+	putUint32LE(params[0:4], uint32(numElements)) //nolint:gosec // G115: integer overflow conversion int -> uint32
 
 	if dtype == tensor.Float32 {
 		putFloat32LE(params[4:8], minBound.(float32))

--- a/internal/backend/webgpu/lazy_compute.go
+++ b/internal/backend/webgpu/lazy_compute.go
@@ -1410,3 +1410,67 @@ func (b *Backend) runSumLazy(input *tensor.RawTensor) (*tensor.RawTensor, error)
 		return nil, errUnsupportedDType(dtype)
 	}
 }
+
+// runClampLazy executes element-wise clamping with lazy result.
+// clamp(x, min, max) - data stays on GPU until Data() is called.
+func (b *Backend) runClampLazy(input *tensor.RawTensor, minBound, maxBound any) (*tensor.RawTensor, error) {
+	dtype := input.DType()
+	if dtype != tensor.Float32 && dtype != tensor.Int32 {
+		return nil, errUnsupportedDType(dtype)
+	}
+
+	numElements := input.NumElements()
+
+	shaderName, shaderCode := selectBinaryShader(dtype, "clamp", clampShader, clampShaderInt32)
+
+	shader := b.compileShader(shaderName, shaderCode)
+	pipeline := b.getOrCreatePipeline(shaderName, shader)
+
+	bufferInput := b.createBufferFromTensor(input)
+	defer bufferInput.Release()
+
+	resultSize := uint64(input.ByteSize()) //nolint:gosec // G115: integer overflow conversion int -> uint64
+	bufferResult := b.device.CreateBuffer(&wgpu.BufferDescriptor{
+		Usage: gputypes.BufferUsageStorage | gputypes.BufferUsageCopySrc | gputypes.BufferUsageCopyDst,
+		Size:  resultSize,
+	})
+
+	params := make([]byte, 16)
+	putUint32LE(params[0:4], uint32(numElements))
+
+	if dtype == tensor.Float32 {
+		putFloat32LE(params[4:8], minBound.(float32))
+		putFloat32LE(params[8:12], maxBound.(float32))
+	} else {
+		putInt32LE(params[4:8], minBound.(int32))
+		putInt32LE(params[8:12], maxBound.(int32))
+	}
+	bufferParams := b.createUniformBuffer(params)
+	defer bufferParams.Release()
+
+	bindGroupLayout := pipeline.GetBindGroupLayout(0)
+	bindGroup := b.device.CreateBindGroupSimple(bindGroupLayout, []wgpu.BindGroupEntry{
+		wgpu.BufferBindingEntry(0, bufferInput, 0, resultSize),
+		wgpu.BufferBindingEntry(1, bufferResult, 0, resultSize),
+		wgpu.BufferBindingEntry(2, bufferParams, 0, 16),
+	})
+	defer bindGroup.Release()
+
+	encoder := b.device.CreateCommandEncoder(nil)
+	computePass := encoder.BeginComputePass(nil)
+	computePass.SetPipeline(pipeline)
+	computePass.SetBindGroup(0, bindGroup, nil)
+	workgroups := uint32((numElements + workgroupSize - 1) / workgroupSize) //nolint:gosec // G115: integer overflow conversion int -> uint32
+	computePass.DispatchWorkgroups(workgroups, 1, 1)
+	computePass.End()
+
+	cmdBuffer := encoder.Finish(nil)
+	b.queueCommand(cmdBuffer)
+
+	return b.createLazyResult(bufferResult, resultSize, input.Shape(), dtype)
+}
+
+// putInt32LE writes an int32 to a byte slice in little-endian order.
+func putInt32LE(b []byte, v int32) {
+	putUint32LE(b, uint32(v)) //nolint:gosec // G115: safe, int32 fits in uint32
+}

--- a/internal/backend/webgpu/ops.go
+++ b/internal/backend/webgpu/ops.go
@@ -392,6 +392,9 @@ func (b *Backend) Abs(x *tensor.RawTensor) *tensor.RawTensor {
 	return result
 }
 
+// Clamp restricts tensor values element-wise to [minBound, maxBound].
+//
+// Supports float32 and int32 dtypes. Will raise a panic if called with unsupported dtype.
 func (b *Backend) Clamp(x *tensor.RawTensor, minBound, maxBound any) *tensor.RawTensor {
 	if x.DType() != tensor.Float32 && x.DType() != tensor.Int32 {
 		panic(fmt.Sprintf("webgpu: Clamp currently supports only Float32 and Int32, got %s", x.DType()))

--- a/internal/backend/webgpu/ops.go
+++ b/internal/backend/webgpu/ops.go
@@ -392,6 +392,23 @@ func (b *Backend) Abs(x *tensor.RawTensor) *tensor.RawTensor {
 	return result
 }
 
+func (b *Backend) Clamp(x *tensor.RawTensor, minBound, maxBound any) *tensor.RawTensor {
+	if x.DType() != tensor.Float32 && x.DType() != tensor.Int32 {
+		panic(fmt.Sprintf("webgpu: Clamp currently supports only Float32 and Int32, got %s", x.DType()))
+	}
+	var result *tensor.RawTensor
+	var err error
+	if b.LazyMode {
+		result, err = b.runClampLazy(x, minBound, maxBound)
+	} else {
+		result, err = b.runClamp(x, minBound, maxBound)
+	}
+	if err != nil {
+		panic("webgpu: Clamp: " + err.Error())
+	}
+	return result
+}
+
 // Erf computes element-wise error function on GPU.
 func (b *Backend) Erf(x *tensor.RawTensor) *tensor.RawTensor {
 	var result *tensor.RawTensor

--- a/internal/backend/webgpu/ops_test.go
+++ b/internal/backend/webgpu/ops_test.go
@@ -3,6 +3,7 @@
 package webgpu
 
 import (
+	"encoding/binary"
 	"math"
 	"testing"
 
@@ -63,6 +64,43 @@ func compareSlices(t *testing.T, expected, actual []float32, tolerance float32) 
 	return true
 }
 
+func createInt32Tensor(t *testing.T, shape tensor.Shape, data []int32) *tensor.RawTensor {
+	t.Helper()
+	raw, err := tensor.NewRaw(shape, tensor.Int32, tensor.WebGPU)
+	if err != nil {
+		t.Fatalf("failed to create tensor: %v", err)
+	}
+	byteData := raw.Data()
+	for i, v := range data {
+		binary.LittleEndian.PutUint32(byteData[i*4:i*4+4], uint32(v))
+	}
+	return raw
+}
+
+func extractInt32Data(t *testing.T, raw *tensor.RawTensor) []int32 {
+	t.Helper()
+	byteData := raw.Data()
+	result := make([]int32, raw.NumElements())
+	for i := range result {
+		result[i] = int32(binary.LittleEndian.Uint32(byteData[i*4 : i*4+4]))
+	}
+	return result
+}
+
+func compareInt32Slices(t *testing.T, expected, actual []int32) bool {
+	t.Helper()
+	if len(expected) != len(actual) {
+		t.Errorf("length mismatch: expected %d, got %d", len(expected), len(actual))
+		return false
+	}
+	for i := range expected {
+		if expected[i] != actual[i] {
+			t.Errorf("value mismatch at index %d: expected %d, got %d", i, expected[i], actual[i])
+			return false
+		}
+	}
+	return true
+}
 func TestAdd(t *testing.T) {
 	if !computeAvailable {
 		t.Skip("WebGPU not available")

--- a/internal/backend/webgpu/shaders.go
+++ b/internal/backend/webgpu/shaders.go
@@ -346,6 +346,48 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 }
 `
 
+// clampShader performs element-wise clamping: result = clamp(x, min, max).
+const clampShader = `
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> result: array<f32>;
+
+struct Params {
+    size: u32,
+    min: f32,
+    max: f32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let idx = global_id.x;
+    if (idx < params.size) {
+        result[idx] = clamp(input[idx], params.min, params.max);
+    }
+}
+`
+
+// clampShaderInt32 performs element-wise clamping for int32: result = clamp(x, min, max).
+const clampShaderInt32 = `
+@group(0) @binding(0) var<storage, read> input: array<i32>;
+@group(0) @binding(1) var<storage, read_write> result: array<i32>;
+
+struct Params {
+    size: u32,
+    min: i32,
+    max: i32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let idx = global_id.x;
+    if (idx < params.size) {
+        result[idx] = clamp(input[idx], params.min, params.max);
+    }
+}
+`
+
 // scalarMulShader performs scalar multiplication: result = x * scalar.
 const scalarMulShader = `
 @group(0) @binding(0) var<storage, read> input: array<f32>;

--- a/internal/tensor/backend.go
+++ b/internal/tensor/backend.go
@@ -44,15 +44,16 @@ type Backend interface {
 	DivScalar(x *RawTensor, scalar any) *RawTensor // divide by scalar
 
 	// Math operations (element-wise)
-	Exp(x *RawTensor) *RawTensor   // exponential
-	Log(x *RawTensor) *RawTensor   // natural logarithm
-	Sqrt(x *RawTensor) *RawTensor  // square root
-	Rsqrt(x *RawTensor) *RawTensor // reciprocal square root (1/sqrt(x))
-	Cos(x *RawTensor) *RawTensor   // cosine
-	Sin(x *RawTensor) *RawTensor   // sine
-	Erf(x *RawTensor) *RawTensor   // error function
-	Sign(x *RawTensor) *RawTensor  // sign function
-	Abs(x *RawTensor) *RawTensor   // absolute value
+	Exp(x *RawTensor) *RawTensor                           // exponential
+	Log(x *RawTensor) *RawTensor                           // natural logarithm
+	Sqrt(x *RawTensor) *RawTensor                          // square root
+	Rsqrt(x *RawTensor) *RawTensor                         // reciprocal square root (1/sqrt(x))
+	Cos(x *RawTensor) *RawTensor                           // cosine
+	Sin(x *RawTensor) *RawTensor                           // sine
+	Erf(x *RawTensor) *RawTensor                           // error function
+	Sign(x *RawTensor) *RawTensor                          // sign function
+	Abs(x *RawTensor) *RawTensor                           // absolute value
+	Clamp(x *RawTensor, minBound, maxBound any) *RawTensor // clamp values to [min, max]
 
 	// Activation functions
 	Softmax(x *RawTensor, dim int) *RawTensor // softmax along dimension

--- a/internal/tensor/dtype.go
+++ b/internal/tensor/dtype.go
@@ -1,6 +1,8 @@
 // Package tensor provides the core tensor types and operations for Born ML framework.
 package tensor
 
+import "fmt"
+
 // DType is a constraint for supported tensor data types.
 // It uses Go generics to ensure compile-time type safety.
 type DType interface {
@@ -72,4 +74,16 @@ func inferDataType[T DType](dummy T) DataType {
 	default:
 		panic("unsupported type")
 	}
+}
+
+// CheckScalarDtype checks if the value matches the expected type.
+//
+// Panics if they do not match.
+func CheckScalarDtype[T int32 | int64 | float32 | float64](val any) T {
+	casted, ok := val.(T)
+	if !ok {
+		panic(fmt.Sprintf("tensor: expected %T, got %T", new(T), val))
+	}
+
+	return casted
 }

--- a/internal/tensor/dtype.go
+++ b/internal/tensor/dtype.go
@@ -76,10 +76,10 @@ func inferDataType[T DType](dummy T) DataType {
 	}
 }
 
-// CheckScalarDtype checks if the value matches the expected type.
+// CheckScalarDType checks if the value matches the expected type.
 //
 // Panics if they do not match.
-func CheckScalarDtype[T int32 | int64 | float32 | float64](val any) T {
+func CheckScalarDType[T DType](val any) T {
 	casted, ok := val.(T)
 	if !ok {
 		panic(fmt.Sprintf("tensor: expected %T, got %T", new(T), val))

--- a/internal/tensor/mock.go
+++ b/internal/tensor/mock.go
@@ -1017,6 +1017,34 @@ func (m *MockBackend) Where(condition, x, y *RawTensor) *RawTensor {
 	return result
 }
 
+// Clamp restricts tensor values element-wise to [minBound, maxBound].
+func (m *MockBackend) Clamp(x *RawTensor, minBound, maxBound any) *RawTensor {
+	result, err := NewRaw(x.Shape(), x.DType(), m.Device())
+	if err != nil {
+		panic(err)
+	}
+	resultData := m.toFloat64Slice(result)
+
+	minFloat := m.anyToFloat64(minBound)
+	maxFloat := m.anyToFloat64(maxBound)
+
+	if minFloat > maxFloat {
+		for i := range resultData {
+			resultData[i] = maxFloat
+		}
+		m.fromFloat64Slice(resultData, result)
+		return result
+	}
+
+	xData := m.toFloat64Slice(x)
+	for i, v := range xData {
+		resultData[i] = min(max(v, minFloat), maxFloat)
+	}
+
+	m.fromFloat64Slice(resultData, result)
+	return result
+}
+
 // Embedding performs embedding lookup (naive implementation).
 // weight: [numEmbeddings, embeddingDim]
 // indices: any shape of int32 indices

--- a/tensor/backend.go
+++ b/tensor/backend.go
@@ -59,15 +59,16 @@ type Backend interface {
 	DivScalar(x *RawTensor, scalar any) *RawTensor // Divide by scalar.
 
 	// Math operations (element-wise).
-	Exp(x *RawTensor) *RawTensor   // Exponential.
-	Log(x *RawTensor) *RawTensor   // Natural logarithm.
-	Sqrt(x *RawTensor) *RawTensor  // Square root.
-	Rsqrt(x *RawTensor) *RawTensor // Reciprocal square root (1/sqrt(x)).
-	Cos(x *RawTensor) *RawTensor   // Cosine.
-	Sin(x *RawTensor) *RawTensor   // Sine.
-	Erf(x *RawTensor) *RawTensor   // Error function (erf).
-	Sign(x *RawTensor) *RawTensor  // Sign function.
-	Abs(x *RawTensor) *RawTensor   // Absolute value.
+	Exp(x *RawTensor) *RawTensor                           // Exponential.
+	Log(x *RawTensor) *RawTensor                           // Natural logarithm.
+	Sqrt(x *RawTensor) *RawTensor                          // Square root.
+	Rsqrt(x *RawTensor) *RawTensor                         // Reciprocal square root (1/sqrt(x)).
+	Cos(x *RawTensor) *RawTensor                           // Cosine.
+	Sin(x *RawTensor) *RawTensor                           // Sine.
+	Erf(x *RawTensor) *RawTensor                           // Error function (erf).
+	Sign(x *RawTensor) *RawTensor                          // Sign function.
+	Abs(x *RawTensor) *RawTensor                           // Absolute value.
+	Clamp(x *RawTensor, minBound, maxBound any) *RawTensor // Clamp values to [min, max].
 
 	// Activation functions.
 	Softmax(x *RawTensor, dim int) *RawTensor // Softmax along dimension.


### PR DESCRIPTION
Implements the clamp tensor operation.  Opted to implement as a composition of other tensor ops, is this the right approach?  

Supported dtypes on CPU - `int32`, `int64`, `float32`, `float64`
Supported dtypes on WebGPU - `int32` and `float32`

Panics in the following cases:
1. Either bound is nil
2. Either bound is NaN
3. Either bound type does not match tensor type