### PR TITLE
v0.9.0: CPU Parallel MatMul + GPU Batched Dispatch + AVX2 SIMD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 # Testing Strategy:
 # - Tests run on Linux, macOS, and Windows (cross-platform framework)
 # - Born ML is a cross-platform ML framework - must work everywhere
-# - Go 1.25+ required (matches go.mod requirement)
+# - Go 1.26+ required (matches go.mod requirement)
 #
 # Branch Strategy (Git Flow):
 # - feature/** branches: Development work
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.25']  # Match go.mod requirement
+        go-version: ['1.26']  # Match go.mod requirement
 
     steps:
     - name: Checkout code
@@ -60,7 +60,7 @@ jobs:
       run: go test -short -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
     - name: Upload coverage to Codecov
-      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25'
+      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.26'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
 
     - name: Run golangci-lint
@@ -103,7 +103,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
 
     - name: Check formatting
@@ -129,7 +129,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
 
     - name: Build MNIST example
@@ -150,7 +150,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
 
     - name: Build all tools
@@ -168,7 +168,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
 
     - name: Run benchmarks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-17
+
+### Added
+
+- **CPU parallel BatchMatMul** — `sync.WaitGroup` + goroutines across batch dimension
+  - Threshold: B ≤ 4 → sequential, B > 4 → parallel (`runtime.NumCPU()` workers)
+  - All 4 variants: Float32, Float64, BroadcastFloat32, BroadcastFloat64
+  - Fixed race condition: capped slice prevents overlapping zero-init across goroutines
+- **CPU cache-tiled blocked MatMul** — 3-5x speedup for large matrices
+  - i-block→k-block→j-block loop order (sequential B-matrix access)
+  - Block sizes: 64 (float32, 16KB L1), 32 (float64, 8KB L1)
+  - Threshold: m×n×k < 262K → naive fallback (overhead > benefit)
+  - Micro-kernel extracted for compiler inlining
+- **AVX2 SIMD MatMul micro-kernel** via Go 1.26 `goexperiment.simd`
+  - `simd/archsimd`: LoadFloat32x8, BroadcastFloat32x8, MulAdd (FMA)
+  - 4-row × 16-wide register block, zero allocations
+  - Benchmark: 128×128 micro-kernel 3693 → 1058 ns/op (**3.49x**)
+  - Build tag: `//go:build amd64 && goexperiment.simd` + scalar fallback
+  - 13 correctness subtests
+- **GPU batched dispatch** — queue lazy ops, single `queue.Submit` on Data() access
+  - `finishAndQueueLazy` queues command buffers instead of immediate Submit
+  - `flushCommands` submits all pending in single variadic `queue.Submit(cmdBufs...)`
+  - All GPU resources (buffers + bind groups) kept alive via `lazyResources` until after Submit
+  - Before: 50+ Submits per transformer forward pass (~25ms overhead). After: 1 Submit per readback
+- **Embedding backward tests** — 5 tests covering 1D/2D shapes, duplicate indices, gradient flow, MulScalar chain
+- **Go 1.26** — minimum Go version updated from 1.25 to 1.26 for `simd/archsimd` support
+
+### Fixed
+
+- **GPU batched dispatch**: bind groups and input buffers kept alive until after queue.Submit (BUG-LAZY-DEFER-RELEASE for all resource types)
+- **GPU buffer copy**: `copyGPUBuffer` flushes pending commands + Poll before copy (prevents reading unsubmitted staging data)
+
 ## [0.8.3] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ make install
 ### Development Setup
 
 **Requirements**:
-- Go 1.25+
+- Go 1.26+ (1.26 required for optional SIMD support via `GOEXPERIMENT=simd`)
 - Make (optional, but recommended)
 - golangci-lint (for linting)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Approach**: PyTorch-inspired API, Burn-inspired architecture, Go best practices
 > **Philosophy**: Correctness → Performance → Features
 
-**Last Updated**: 2026-05-16 | **Current Version**: v0.8.3 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.8.0 (GoGPU Migration) → v0.8.1 (LLaMA Inference) → v0.8.2 (Tokenizer + Backward Ops) → v1.0.0 LTS
+**Last Updated**: 2026-05-17 | **Current Version**: v0.9.0 | **Strategy**: Core → GPU → LLM → ONNX → Inference Opt → Production → v1.0 LTS | **Milestone**: v0.8.0 (GoGPU Migration) → v0.8.1 (LLaMA Inference) → v0.8.2 (Tokenizer + Backward Ops) → v1.0.0 LTS
 
 ---
 
@@ -82,8 +82,10 @@ v0.8.1 (LLaMA Inference, GGUF Model Loading) ✅ RELEASED (2026-05-15)
        ↓ (tokenizer bug fix)
 v0.8.2 (Tokenizer Fix, Backward Ops Migration, Scalar Gradient Fix) ✅ RELEASED (2026-05-16)
        ↓ (GPU scatter-add shaders)
-v0.8.3 (GPU SelectAdd/ScatterAdd Shaders) → CURRENT (2026-05-16)
-       ↓ (CPU multi-threading, quantization improvements)
+v0.8.3 (GPU SelectAdd/ScatterAdd Shaders) ✅ RELEASED (2026-05-16)
+       ↓ (CPU parallel + GPU batching + SIMD)
+v0.9.0 (CPU Parallel, GPU Batching, AVX2 SIMD) → CURRENT (2026-05-17)
+       ↓ (quantization, production serving)
 v0.9.0 (CPU Multi-thread, PagedAttention, Kernel Fusion) → June 2026
        ↓ (scale & stability)
 v0.10.0 (Multi-GPU, SIMD, Gradient Checkpointing) → Aug 2026
@@ -193,12 +195,19 @@ v1.0.0 LTS → After API stabilization
 - Refactored: 7 backward ops migrated from CPU-fallback to forward composition (ADR-009).
 - Added: SelectAdd, ScatterAdd backend ops for Embedding/Gather backward.
 
-**v0.8.3** = GPU SelectAdd/ScatterAdd Shaders → CURRENT (2026-05-16)
-- WGSL compute shaders for scatter-add (no f32 atomics, per-destination-row/element approach)
-- Eliminates 27K GPU→CPU readbacks per backward step
-- HRM training: step time from minutes to seconds
+**v0.8.3** = GPU SelectAdd/ScatterAdd Shaders ✅ RELEASED (2026-05-16)
+- WGSL compute shaders for scatter-add (no f32 atomics)
+- 27K readbacks → 1 GPU dispatch. HRM: minutes → seconds
 
-**v0.9.0** = CPU Multi-thread & Production Serving → June 2026
+**v0.9.0** = CPU Parallel + GPU Batching + AVX2 SIMD → CURRENT (2026-05-17)
+- CPU BatchMatMul goroutine parallelism (2-4x, threshold B>4)
+- CPU cache-tiled blocked MatMul (3-5x, L1-aligned 64×64 blocks)
+- AVX2 SIMD micro-kernel via Go 1.26 `goexperiment.simd` (3.5x)
+- GPU batched dispatch: queue ops, single Submit on Data() (50→1 submits)
+- Go 1.26 minimum (for simd/archsimd support)
+- Combined CPU speedup: ~20-70x for large batch MatMul on AVX2
+
+**v0.10.0** = Quantization & Production Serving → July 2026
 - CPU multi-threaded MatMul/BatchMatMul (TASK-133)
 - PagedAttention (>90% GPU utilization)
 - Continuous Batching (10-23x throughput)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Born ML Framework - Architecture
 
 **Status**: Living Document
-**Last Updated**: 2026-05-16
+**Last Updated**: 2026-05-17
 
 ---
 
@@ -111,11 +111,28 @@ GPU Op → GPU Op → GPU Op → AsFloat32()
 
 ---
 
+## CPU Backend Performance
+
+### Parallel BatchMatMul
+
+Batches are independent — parallelized via `sync.WaitGroup` + goroutines. Threshold: B ≤ 4 sequential, B > 4 parallel. Workers: `runtime.NumCPU()`.
+
+### Cache-Tiled Blocked MatMul
+
+i-block→k-block→j-block loop order keeps both A and B blocks in L1 cache. Block size: 64 (float32, 16KB), 32 (float64, 8KB). 3-5x speedup for matrices > 64×64.
+
+### AVX2 SIMD (Go 1.26+, experimental)
+
+Optional SIMD micro-kernel via `goexperiment.simd` + `simd/archsimd`. 4-row × 16-wide register block with FMA. Build with `GOEXPERIMENT=simd go build`. Scalar fallback compiles without the flag. 3.5x speedup on AVX2 hardware.
+
+---
+
 ## WebGPU Backend
 
 Pure Go GPU backend via [gogpu/wgpu](https://github.com/gogpu/wgpu) — zero CGO, zero runtime dependencies.
 
 - **Compute shaders**: Hand-written WGSL (not compiler DSL like Burn's CubeCL)
+- **Batched dispatch**: Lazy ops queue command buffers; single `queue.Submit` on first `Data()` access. Reduces 50+ submits per forward pass to 1.
 - **Buffer pool**: Reuses GPU memory allocations
 - **Pipeline cache**: Caches compiled compute pipelines
 - **Vulkan primary**: `BackendsVulkan` for compute workloads
@@ -145,6 +162,7 @@ GGUF file → gguf.ParseFile → TensorConverter → models/llama.LoadGGUF
 | Hand-written WGSL shaders | Control over GPU kernels | ADR-004 |
 | Core API over HAL-direct for wgpu | Stability, portability | ADR-005 |
 | Backward via forward composition | GPU-native gradients, Burn alignment | ADR-009 |
+| CPU parallel + GPU batching + SIMD | Performance parity with references | ADR-010 |
 
 Full ADR list: `docs/dev/ADR-*.md`
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -498,7 +498,7 @@ model := born.LoadONNX("model.onnx")
 
 ### Q: Is Born stable enough?
 
-**A:** Current status (v0.8.3):
+**A:** Current status (v0.9.0):
 - ✅ Core API stable (tensor, nn, optim, autodiff)
 - ✅ Production-tested (MNIST 97%+, GPU 123x speedup)
 - ✅ LLM inference: LLaMA via `models/llama.LoadGGUF()`, verified on TinyLlama 1.1B Q8_0 and Q4_K_M

--- a/internal/backend/cpu/matmul.go
+++ b/internal/backend/cpu/matmul.go
@@ -99,7 +99,7 @@ func matmulFloat32(c, a, b []float32, m, k, n int) {
 // When an AVX2 SIMD kernel is available (amd64, built with GOEXPERIMENT=simd),
 // simdMicroKernelF32 is non-nil and the work is delegated to avx2MicroKernelF32.
 // Otherwise the scalar i→k→j loop runs: aVal is hoisted out of the j-loop and
-// b[kIdx*n+j] access is sequential (row-major) to maximise cache utilisation.
+// b[kIdx*n+j] access is sequential (row-major) to maximize cache utilization.
 func matmulMicroKernelF32(c, a, b []float32, k, n, ii, iEnd, kk, kEnd, jj, jEnd int) {
 	if simdMicroKernelF32 != nil {
 		simdMicroKernelF32(c, a, b, k, n, ii, iEnd, kk, kEnd, jj, jEnd)

--- a/internal/backend/webgpu/lazy_compute.go
+++ b/internal/backend/webgpu/lazy_compute.go
@@ -242,6 +242,12 @@ func (b *Backend) finishAndQueueLazy(
 // copyGPUBuffer creates a GPU-to-GPU copy without CPU round-trip.
 // This is critical for LazyMode performance - avoids GPU→CPU→GPU transfers.
 func (b *Backend) copyGPUBuffer(srcBuffer *wgpu.Buffer, size uint64) *wgpu.Buffer {
+	// Flush pending commands first — srcBuffer may be a staging buffer from a
+	// lazy op whose command buffer hasn't been submitted yet. Without this
+	// flush, CopyBufferToBuffer would read uninitialized staging data.
+	b.flushCommands()
+	b.device.Poll(wgpu.PollWait)
+
 	dstBuffer, err := b.device.CreateBuffer(&wgpu.BufferDescriptor{
 		Usage: gputypes.BufferUsageStorage | gputypes.BufferUsageCopySrc | gputypes.BufferUsageCopyDst,
 		Size:  size,


### PR DESCRIPTION
## Summary

Performance release: CPU and GPU compute backends optimized per ADR-010.

### CPU Backend
- **Parallel BatchMatMul**: goroutines + WaitGroup, threshold B>4 (2-4x)
- **Cache-tiled blocked MatMul**: L1-aligned 64×64 blocks, i→k→j order (3-5x)
- **AVX2 SIMD micro-kernel**: `goexperiment.simd` + `simd/archsimd` FMA (3.5x)
- Combined: ~20-70x for large batch MatMul on AVX2

### GPU Backend
- **Batched dispatch**: queue lazy ops, single `queue.Submit` on Data() access
- Before: 50+ Submits per transformer forward (~25ms overhead)
- After: 1 Submit per readback
- All GPU resources (buffers + bind groups) kept alive via `lazyResources`

### Infrastructure
- Go 1.26 minimum (for `simd/archsimd`)
- 5 embedding backward tests (closes coverage gap)
- golangci-lint v2 compatible

## Commits (8)

```
b95a439 docs: update CHANGELOG/ROADMAP/README/ARCHITECTURE/USE_CASES for v0.9.0
3048f4f fix(webgpu): flush+poll pending commands before GPU buffer copy
ae061e6 fix(webgpu): keep bind groups alive in batched dispatch
8c855f5 feat(cpu): AVX2 SIMD MatMul micro-kernel via goexperiment.simd — 3.5x
281bffd feat(cpu): cache-tiled blocked MatMul — 3-5x for large matrices
6cb0480 feat(webgpu): batched GPU dispatch — queue ops, single Submit on Data()
c2c4b9b feat(cpu): parallel BatchMatMul via goroutines — 2-4x on B>4
5b4df77 test(nn): add 5 embedding backward tests — closes test coverage gap
```

## Test plan

- [x] 20/20 test packages pass (Go 1.26.3)
- [x] golangci-lint v2.12.2: 0 issues
- [x] go vet: clean
- [x] gofmt: clean
- [x] SIMD build: `GOEXPERIMENT=simd go build ./...` passes
- [x] SIMD tests: 13 correctness subtests pass
- [x] GPU scatter-add tests: 13 tests pass
- [ ] CI passes (Ubuntu/macOS/Windows)
- [ ] HRM GPU training validates (in progress)