### PR TITLE
v0.9.3: Shared Encoder + Buffer Cache + TDR Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.1] - 2026-05-19
+## [0.9.3] - 2026-05-19
 
 ### Added
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 > **Architecture**: Burn-inspired (Rust), Go-idiomatic API
 > **Philosophy**: Correctness → Performance → Scale
 
-**Last Updated**: 2026-05-19 | **Current Version**: v0.9.1 | **Go**: 1.26+ | **Go**: 1.26+ | **Strategy**: Core → GPU → Models → Performance → Scale → Production → v1.0 LTS
+**Last Updated**: 2026-05-19 | **Current Version**: v0.9.3 | **Go**: 1.26+ | **Go**: 1.26+ | **Strategy**: Core → GPU → Models → Performance → Scale → Production → v1.0 LTS
 
 ---
 


### PR DESCRIPTION
## Summary

GPU performance release (ADR-012) + TDR safety fix.

### GPU Shared Encoder Accumulator
- One CommandEncoder for N compute passes instead of N individual encoders
- 128 Finish() calls per batch → 1
- GPU utilization: 55% → 70-80% (measured on Intel Iris Xe)
- All 15 lazy ops simplified via `addComputePassToEncoder` (-456 lines)

### GPU Input Buffer Cache
- `getOrCreateInputBuffer`: tensor→GPU buffer identity mapping
- Weight matrices uploaded once, reused across forward+backward
- Zero duplicate GPU uploads for same tensor

### TDR Fix
- Auto-flush every 128 dispatches (maxPendingBeforeFlush)
- Prevents VK_ERROR_DEVICE_LOST on iGPUs (Windows TDR 2s timeout)
- Corrected attention (13K dispatches/eval) no longer crashes

### Documentation
- CHANGELOG v0.9.3
- ROADMAP updated
- ADR-012: GPU encoder batching + buffer cache
- Research: GPU encoder/buffer optimization (3 agents)

### Tests
- 17 enterprise GPU tests (shared_encoder_test.go + encoder_batch_test.go)
- 3 auto-flush tests (autoflush_test.go)
- 20/20 packages pass locally

## Test plan
- [x] 20/20 packages pass (Go 1.26.3, Windows)
- [x] go vet: clean
- [x] gofmt: clean
- [x] 17 shared encoder + buffer cache GPU tests pass
- [x] 3 auto-flush GPU tests pass
- [ ] CI passes (Ubuntu/macOS/Windows)