### PR TITLE
v0.9.2: LLaMA Forward fix + Release + enterprise tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       shell: bash
       env:
         GOGPU_GRAPHICS_API: software
-      run: go test -short -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+      run: go test -short -v -race -timeout 20m -coverprofile=coverage.txt -covermode=atomic ./...
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.26'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-06-15
+
+### Fixed
+
+- **LLaMA Forward signature** — `interface{ Clear() }` → `generate.KVCache`. Model now correctly satisfies `generate.LLMModel` interface ([#68](https://github.com/born-ml/born/issues/68))
+- **LLaMA Release()** — properly releases all GPU buffers for model parameters (Embed, Layers, Norm, Head). Previously missing — README example `defer model.Release()` was broken ([#68](https://github.com/born-ml/born/issues/68))
+
+### Added
+
+- **Compile-time LLMModel check** — `var _ generate.LLMModel = (*Model[...])(nil)` prevents future interface drift
+- **6 enterprise tests** — Release safety (double-free), KV cache incremental decoding, deterministic forward, NaN/Inf check, cache Clear + layer count
+- **Open Collective sponsorship** — badges in README, Sponsors/Backers section, FUNDING.yml (org-level)
+
 ## [0.9.1] - 2026-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Test Status](https://github.com/born-ml/born/actions/workflows/test.yml/badge.svg)](https://github.com/born-ml/born/actions/workflows/test.yml)
 [![Codecov](https://codecov.io/gh/born-ml/born/branch/main/graph/badge.svg?token=CODECOV_TOKEN)](https://codecov.io/gh/born-ml/born)
 [![Discussions](https://img.shields.io/github/discussions/born-ml/born?logo=github&label=Discussions)](https://github.com/born-ml/born/discussions)
+<a href="https://opencollective.com/born-ml"><img src="https://opencollective.com/born-ml/all/badge.svg?label=financial+contributors" alt="Financial Contributors on Open Collective"></a>
 
 > **"Models are born production-ready"**
 
@@ -537,6 +538,20 @@ No DLL downloads, no `LD_LIBRARY_PATH`, no system-level installs. True single bi
   - [Q&A](https://github.com/born-ml/born/discussions/3)
   - [Feature Requests](https://github.com/born-ml/born/discussions/4)
 - **Issues**: [Report bugs or request features](https://github.com/born-ml/born/issues)
+
+---
+
+## Sponsors
+
+Born ML is an independent open-source project. Development is sustained by contributors and sponsors.
+
+<a href="https://opencollective.com/born-ml"><img src="https://opencollective.com/born-ml/sponsors.svg?width=890&button=false" alt="Sponsors"></a>
+
+### Backers
+
+<a href="https://opencollective.com/born-ml"><img src="https://opencollective.com/born-ml/backers.svg?width=890&button=false" alt="Backers"></a>
+
+<a href="https://opencollective.com/born-ml"><img src="https://img.shields.io/badge/Sponsor-Open%20Collective-7FADF2?logo=opencollective" alt="Sponsor on Open Collective"></a>
 
 ---
 

--- a/models/llama/model.go
+++ b/models/llama/model.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/born-ml/born/internal/generate"
 	"github.com/born-ml/born/internal/nn"
 	"github.com/born-ml/born/internal/tensor"
 )
@@ -326,6 +327,23 @@ func NewModel[B tensor.Backend](cfg Config, backend B, opts ...Option[B]) *Model
 	}
 }
 
+// Release frees all GPU buffers held by the model's parameters.
+// Call when the model is no longer needed to reclaim GPU memory immediately
+// instead of waiting for GC. Safe to call multiple times.
+func (m *Model[B]) Release() {
+	release := func(params []*nn.Parameter[B]) {
+		for _, p := range params {
+			p.Tensor().Raw().ReleaseGPU()
+		}
+	}
+	release(m.Embed.Parameters())
+	for _, layer := range m.Layers {
+		release(layer.Parameters())
+	}
+	release(m.Norm.Parameters())
+	release(m.Head.Parameters())
+}
+
 // Forward performs a forward pass and returns logits.
 //
 // This method satisfies the generate.LLMModel interface.
@@ -341,7 +359,7 @@ func NewModel[B tensor.Backend](cfg Config, backend B, opts ...Option[B]) *Model
 // Returns logits [batch, seq_len, vocab_size] as a *tensor.RawTensor.
 func (m *Model[B]) Forward(
 	input *tensor.RawTensor,
-	cache interface{ Clear() },
+	cache generate.KVCache,
 	startPos int,
 ) *tensor.RawTensor {
 	// Convert raw int32 input to typed tensor for embedding lookup.

--- a/models/llama/model_test.go
+++ b/models/llama/model_test.go
@@ -5,12 +5,18 @@
 package llama
 
 import (
+	"math"
 	"testing"
 
 	"github.com/born-ml/born/internal/autodiff"
 	"github.com/born-ml/born/internal/backend/cpu"
+	"github.com/born-ml/born/internal/generate"
 	"github.com/born-ml/born/internal/tensor"
 )
+
+// Compile-time interface satisfaction check.
+// If Model does not implement LLMModel, this line fails to compile.
+var _ generate.LLMModel = (*Model[cpuBackend])(nil)
 
 // cpuBackend is the concrete type used in forward-pass tests.
 // SiLU (used by SwiGLU FFN) requires autodiff.AutodiffBackend wrapper.
@@ -181,6 +187,134 @@ func TestWithAttentionFunc(t *testing.T) {
 
 	if !called {
 		t.Error("custom AttentionFunc was not called during Forward")
+	}
+}
+
+// TestRelease verifies that Release frees parameters and is safe to call multiple times.
+func TestRelease(t *testing.T) {
+	backend := newCPUBackend()
+	cfg := tinyConfig()
+	model := NewModel(cfg, backend)
+
+	params := model.Parameters()
+	if len(params) == 0 {
+		t.Fatal("model has no parameters before Release")
+	}
+
+	// First Release must not panic.
+	model.Release()
+
+	// Second Release (double-free) must not panic.
+	model.Release()
+}
+
+// TestForward_WithKVCache verifies incremental decoding via KV cache.
+// First call processes a prompt (multiple tokens), second call decodes one token
+// using cached keys/values. Output shapes must match expectations.
+func TestForward_WithKVCache(t *testing.T) {
+	backend := newCPUBackend()
+	cfg := tinyConfig()
+	model := NewModel(cfg, backend)
+	cache := NewModelCache(cfg, cfg.MaxSeqLen, backend)
+
+	promptLen := 4
+	prompt := makeInt32Input(1, promptLen, cfg.VocabSize)
+
+	// Prefill: full prompt, startPos=0.
+	logits := model.Forward(prompt, cache, 0)
+	if logits == nil {
+		t.Fatal("prefill Forward returned nil")
+	}
+	wantShape := tensor.Shape{1, promptLen, cfg.VocabSize}
+	if !logits.Shape().Equal(wantShape) {
+		t.Fatalf("prefill shape = %v, want %v", logits.Shape(), wantShape)
+	}
+
+	// Decode: one token, startPos=promptLen (cached).
+	nextToken := makeInt32Input(1, 1, cfg.VocabSize)
+	logits2 := model.Forward(nextToken, cache, promptLen)
+	if logits2 == nil {
+		t.Fatal("decode Forward returned nil")
+	}
+	wantShape2 := tensor.Shape{1, 1, cfg.VocabSize}
+	if !logits2.Shape().Equal(wantShape2) {
+		t.Fatalf("decode shape = %v, want %v", logits2.Shape(), wantShape2)
+	}
+}
+
+// TestForward_Deterministic verifies that two forward passes with the same
+// input and no cache produce identical logits.
+func TestForward_Deterministic(t *testing.T) {
+	backend := newCPUBackend()
+	cfg := tinyConfig()
+	model := NewModel(cfg, backend)
+
+	input := makeInt32Input(1, 3, cfg.VocabSize)
+
+	logits1 := model.Forward(input, nil, 0)
+	logits2 := model.Forward(input, nil, 0)
+
+	data1 := logits1.AsFloat32()
+	data2 := logits2.AsFloat32()
+
+	if len(data1) != len(data2) {
+		t.Fatalf("logit lengths differ: %d vs %d", len(data1), len(data2))
+	}
+	for i := range data1 {
+		if data1[i] != data2[i] {
+			t.Errorf("logits[%d] = %f vs %f (not deterministic)", i, data1[i], data2[i])
+			break
+		}
+	}
+}
+
+// TestForward_LogitsFinite verifies that forward pass produces no NaN/Inf values.
+func TestForward_LogitsFinite(t *testing.T) {
+	backend := newCPUBackend()
+	cfg := tinyConfig()
+	model := NewModel(cfg, backend)
+
+	input := makeInt32Input(1, 4, cfg.VocabSize)
+	logits := model.Forward(input, nil, 0)
+	data := logits.AsFloat32()
+
+	for i, v := range data {
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			t.Fatalf("logits[%d] = %f (NaN or Inf)", i, v)
+		}
+	}
+}
+
+// TestModelCache_Clear verifies that cache.Clear() does not panic
+// and that forward works correctly after clearing.
+func TestModelCache_Clear(t *testing.T) {
+	backend := newCPUBackend()
+	cfg := tinyConfig()
+	model := NewModel(cfg, backend)
+	cache := NewModelCache(cfg, cfg.MaxSeqLen, backend)
+
+	// Fill cache with a forward pass.
+	input := makeInt32Input(1, 3, cfg.VocabSize)
+	model.Forward(input, cache, 0)
+
+	// Clear must not panic.
+	cache.Clear()
+
+	// Forward after clear must succeed (fresh cache).
+	logits := model.Forward(input, cache, 0)
+	if logits == nil {
+		t.Fatal("Forward after cache.Clear returned nil")
+	}
+}
+
+// TestNewModelCache_LayerCount verifies that the cache has one entry per layer.
+func TestNewModelCache_LayerCount(t *testing.T) {
+	backend := newCPUBackend()
+	cfg := tinyConfig()
+	cache := NewModelCache(cfg, cfg.MaxSeqLen, backend)
+
+	if len(cache.layers) != cfg.NumLayers {
+		t.Errorf("cache has %d layers, want %d", len(cache.layers), cfg.NumLayers)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #68 (reported by @bennibbelink) — LLaMA example in README doesn't work.

### Bug fixes
- **Forward signature**: `interface{ Clear() }` → `generate.KVCache` — Model now satisfies `generate.LLMModel`
- **Release()**: properly frees all GPU buffers for model parameters (Embed, Layers, Norm, Head)

### Tests (6 new)
- `var _ generate.LLMModel` compile-time interface check
- `TestRelease` — double-free safety
- `TestForward_WithKVCache` — prefill + incremental decode
- `TestForward_Deterministic` — identical outputs on same input
- `TestForward_LogitsFinite` — no NaN/Inf
- `TestModelCache_Clear` + `TestNewModelCache_LayerCount`

### Sponsorship
- Open Collective badge + Sponsors/Backers section in README

## Test plan
- [x] `go build ./...` — clean
- [x] `golangci-lint` — 0 issues
- [x] 31 llama tests pass (6 new)
- [ ] CI (Ubuntu/macOS/Windows)