### PR TITLE
feat(simd): SIMD implementations for add, sub, mul, div

### DIFF
--- a/internal/backend/cpu/ops_float32.go
+++ b/internal/backend/cpu/ops_float32.go
@@ -7,24 +7,40 @@ import (
 // Float32 inplace operations
 
 func addInplaceFloat32(a, b []float32) {
+	if simdAddInplaceFloat32 != nil {
+		simdAddInplaceFloat32(a, b)
+		return
+	}
 	for i := range a {
 		a[i] += b[i]
 	}
 }
 
 func subInplaceFloat32(a, b []float32) {
+	if simdSubInplaceFloat32 != nil {
+		simdSubInplaceFloat32(a, b)
+		return
+	}
 	for i := range a {
 		a[i] -= b[i]
 	}
 }
 
 func mulInplaceFloat32(a, b []float32) {
+	if simdMulInplaceFloat32 != nil {
+		simdMulInplaceFloat32(a, b)
+		return
+	}
 	for i := range a {
 		a[i] *= b[i]
 	}
 }
 
 func divInplaceFloat32(a, b []float32) {
+	if simdDivInplaceFloat32 != nil {
+		simdDivInplaceFloat32(a, b)
+		return
+	}
 	for i := range a {
 		a[i] /= b[i]
 	}
@@ -33,24 +49,40 @@ func divInplaceFloat32(a, b []float32) {
 // Float32 vectorized operations
 
 func addVectorizedFloat32(dst, a, b []float32) {
+	if simdAddVectorizedFloat32 != nil {
+		simdAddVectorizedFloat32(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] + b[i]
 	}
 }
 
 func subVectorizedFloat32(dst, a, b []float32) {
+	if simdSubVectorizedFloat32 != nil {
+		simdSubVectorizedFloat32(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] - b[i]
 	}
 }
 
 func mulVectorizedFloat32(dst, a, b []float32) {
+	if simdMulVectorizedFloat32 != nil {
+		simdMulVectorizedFloat32(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] * b[i]
 	}
 }
 
 func divVectorizedFloat32(dst, a, b []float32) {
+	if simdDivVectorizedFloat32 != nil {
+		simdDivVectorizedFloat32(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] / b[i]
 	}

--- a/internal/backend/cpu/ops_float32_simd_amd64.go
+++ b/internal/backend/cpu/ops_float32_simd_amd64.go
@@ -1,0 +1,266 @@
+//go:build amd64 && goexperiment.simd
+
+package cpu
+
+import "simd/archsimd"
+
+// Declared here for amd64+goexperiment.simd builds; the stub file provides the
+// same declaration for all other platforms/configurations.
+var simdAddInplaceFloat32 func(a, b []float32)
+var simdSubInplaceFloat32 func(a, b []float32)
+var simdMulInplaceFloat32 func(a, b []float32)
+var simdDivInplaceFloat32 func(a, b []float32)
+
+var simdAddVectorizedFloat32 func(dst, a, b []float32)
+var simdSubVectorizedFloat32 func(dst, a, b []float32)
+var simdMulVectorizedFloat32 func(dst, a, b []float32)
+var simdDivVectorizedFloat32 func(dst, a, b []float32)
+
+func init() {
+	if archsimd.X86.AVX() {
+		simdAddInplaceFloat32 = avxAddInplaceFloat32
+		simdSubInplaceFloat32 = avxSubInplaceFloat32
+		simdMulInplaceFloat32 = avxMulInplaceFloat32
+		simdDivInplaceFloat32 = avxDivInplaceFloat32
+
+		simdAddVectorizedFloat32 = avxAddVectorizedFloat32
+		simdSubVectorizedFloat32 = avxSubVectorizedFloat32
+		simdMulVectorizedFloat32 = avxMulVectorizedFloat32
+		simdDivVectorizedFloat32 = avxDivVectorizedFloat32
+	}
+	if archsimd.X86.AVX512() {
+		simdAddInplaceFloat32 = avx512AddInplaceFloat32
+		simdSubInplaceFloat32 = avx512SubInplaceFloat32
+		simdMulInplaceFloat32 = avx512MulInplaceFloat32
+		simdDivInplaceFloat32 = avx512DivInplaceFloat32
+
+		simdAddVectorizedFloat32 = avx512AddVectorizedFloat32
+		simdSubVectorizedFloat32 = avx512SubVectorizedFloat32
+		simdMulVectorizedFloat32 = avx512MulVectorizedFloat32
+		simdDivVectorizedFloat32 = avx512DivVectorizedFloat32
+	}
+}
+
+func avxAddInplaceFloat32(a, b []float32) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat32x8Slice(b[i : i+8])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] += b[i]
+	}
+}
+
+func avx512AddInplaceFloat32(a, b []float32) {
+	n := len(a)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadFloat32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadFloat32x16Slice(b[i : i+16])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(a[i : i+16])
+	}
+	for ; i < n; i++ {
+		a[i] += b[i]
+	}
+}
+
+func avxSubInplaceFloat32(a, b []float32) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat32x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] -= b[i]
+	}
+}
+
+func avx512SubInplaceFloat32(a, b []float32) {
+	n := len(a)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadFloat32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadFloat32x16Slice(b[i : i+16])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(a[i : i+16])
+	}
+	for ; i < n; i++ {
+		a[i] -= b[i]
+	}
+}
+
+func avxMulInplaceFloat32(a, b []float32) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat32x8Slice(b[i : i+8])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] *= b[i]
+	}
+}
+
+func avx512MulInplaceFloat32(a, b []float32) {
+	n := len(a)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadFloat32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadFloat32x16Slice(b[i : i+16])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(a[i : i+16])
+	}
+	for ; i < n; i++ {
+		a[i] *= b[i]
+	}
+}
+
+func avxDivInplaceFloat32(a, b []float32) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat32x8Slice(b[i : i+8])
+		divLoaded := aLoaded.Div(bLoaded)
+		divLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] /= b[i]
+	}
+}
+
+func avx512DivInplaceFloat32(a, b []float32) {
+	n := len(a)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadFloat32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadFloat32x16Slice(b[i : i+16])
+		divLoaded := aLoaded.Div(bLoaded)
+		divLoaded.StoreSlice(a[i : i+16])
+	}
+	for ; i < n; i++ {
+		a[i] /= b[i]
+	}
+}
+
+func avxAddVectorizedFloat32(dst, a, b []float32) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat32x8Slice(b[i : i+8])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] + b[i]
+	}
+}
+
+func avx512AddVectorizedFloat32(dst, a, b []float32) {
+	n := len(dst)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadFloat32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadFloat32x16Slice(b[i : i+16])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(dst[i : i+16])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] + b[i]
+	}
+}
+
+func avxSubVectorizedFloat32(dst, a, b []float32) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat32x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] - b[i]
+	}
+}
+
+func avx512SubVectorizedFloat32(dst, a, b []float32) {
+	n := len(dst)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadFloat32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadFloat32x16Slice(b[i : i+16])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+16])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] - b[i]
+	}
+}
+
+func avxMulVectorizedFloat32(dst, a, b []float32) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat32x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Mul(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] * b[i]
+	}
+}
+
+func avx512MulVectorizedFloat32(dst, a, b []float32) {
+	n := len(dst)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadFloat32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadFloat32x16Slice(b[i : i+16])
+		subLoaded := aLoaded.Mul(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+16])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] * b[i]
+	}
+}
+
+func avxDivVectorizedFloat32(dst, a, b []float32) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat32x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Div(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] / b[i]
+	}
+}
+
+func avx512DivVectorizedFloat32(dst, a, b []float32) {
+	n := len(dst)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadFloat32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadFloat32x16Slice(b[i : i+16])
+		subLoaded := aLoaded.Div(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+16])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] / b[i]
+	}
+}

--- a/internal/backend/cpu/ops_float32_simd_amd64.go
+++ b/internal/backend/cpu/ops_float32_simd_amd64.go
@@ -241,8 +241,8 @@ func avxMulVectorizedFloat32(dst, a, b []float32) {
 	for ; i+8 <= n; i += 8 {
 		aLoaded := archsimd.LoadFloat32x8Slice(a[i : i+8])
 		bLoaded := archsimd.LoadFloat32x8Slice(b[i : i+8])
-		subLoaded := aLoaded.Mul(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+8])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(dst[i : i+8])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] * b[i]
@@ -257,8 +257,8 @@ func avx512MulVectorizedFloat32(dst, a, b []float32) {
 	for ; i+16 <= n; i += 16 {
 		aLoaded := archsimd.LoadFloat32x16Slice(a[i : i+16])
 		bLoaded := archsimd.LoadFloat32x16Slice(b[i : i+16])
-		subLoaded := aLoaded.Mul(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+16])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(dst[i : i+16])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] * b[i]
@@ -273,8 +273,8 @@ func avxDivVectorizedFloat32(dst, a, b []float32) {
 	for ; i+8 <= n; i += 8 {
 		aLoaded := archsimd.LoadFloat32x8Slice(a[i : i+8])
 		bLoaded := archsimd.LoadFloat32x8Slice(b[i : i+8])
-		subLoaded := aLoaded.Div(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+8])
+		divLoaded := aLoaded.Div(bLoaded)
+		divLoaded.StoreSlice(dst[i : i+8])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] / b[i]
@@ -289,8 +289,8 @@ func avx512DivVectorizedFloat32(dst, a, b []float32) {
 	for ; i+16 <= n; i += 16 {
 		aLoaded := archsimd.LoadFloat32x16Slice(a[i : i+16])
 		bLoaded := archsimd.LoadFloat32x16Slice(b[i : i+16])
-		subLoaded := aLoaded.Div(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+16])
+		divLoaded := aLoaded.Div(bLoaded)
+		divLoaded.StoreSlice(dst[i : i+16])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] / b[i]

--- a/internal/backend/cpu/ops_float32_simd_amd64.go
+++ b/internal/backend/cpu/ops_float32_simd_amd64.go
@@ -41,6 +41,8 @@ func init() {
 	}
 }
 
+// avxAddInplaceFloat32 computes a[i] += b[i] using AVX (256-bit, 8 float32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avxAddInplaceFloat32(a, b []float32) {
 	n := len(a)
 	i := 0
@@ -55,6 +57,8 @@ func avxAddInplaceFloat32(a, b []float32) {
 	}
 }
 
+// avx512AddInplaceFloat32 computes a[i] += b[i] using AVX-512 (512-bit, 16 float32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512AddInplaceFloat32(a, b []float32) {
 	n := len(a)
 	i := 0
@@ -69,6 +73,8 @@ func avx512AddInplaceFloat32(a, b []float32) {
 	}
 }
 
+// avxSubInplaceFloat32 computes a[i] -= b[i] using AVX (256-bit, 8 float32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avxSubInplaceFloat32(a, b []float32) {
 	n := len(a)
 	i := 0
@@ -83,6 +89,8 @@ func avxSubInplaceFloat32(a, b []float32) {
 	}
 }
 
+// avx512SubInplaceFloat32 computes a[i] -= b[i] using AVX-512 (512-bit, 16 float32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512SubInplaceFloat32(a, b []float32) {
 	n := len(a)
 	i := 0
@@ -97,6 +105,8 @@ func avx512SubInplaceFloat32(a, b []float32) {
 	}
 }
 
+// avxMulInplaceFloat32 computes a[i] *= b[i] using AVX (256-bit, 8 float32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avxMulInplaceFloat32(a, b []float32) {
 	n := len(a)
 	i := 0
@@ -111,6 +121,8 @@ func avxMulInplaceFloat32(a, b []float32) {
 	}
 }
 
+// avx512MulInplaceFloat32 computes a[i] *= b[i] using AVX-512 (512-bit, 16 float32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512MulInplaceFloat32(a, b []float32) {
 	n := len(a)
 	i := 0
@@ -125,6 +137,8 @@ func avx512MulInplaceFloat32(a, b []float32) {
 	}
 }
 
+// avxDivInplaceFloat32 computes a[i] /= b[i] using AVX (256-bit, 8 float32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avxDivInplaceFloat32(a, b []float32) {
 	n := len(a)
 	i := 0
@@ -139,6 +153,8 @@ func avxDivInplaceFloat32(a, b []float32) {
 	}
 }
 
+// avx512DivInplaceFloat32 computes a[i] /= b[i] using AVX-512 (512-bit, 16 float32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512DivInplaceFloat32(a, b []float32) {
 	n := len(a)
 	i := 0
@@ -153,6 +169,8 @@ func avx512DivInplaceFloat32(a, b []float32) {
 	}
 }
 
+// avxAddVectorizedFloat32 computes dst[i] = a[i] + b[i] using AVX (256-bit, 8 float32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avxAddVectorizedFloat32(dst, a, b []float32) {
 	n := len(dst)
 	i := 0
@@ -167,6 +185,8 @@ func avxAddVectorizedFloat32(dst, a, b []float32) {
 	}
 }
 
+// avx512AddVectorizedFloat32 computes dst[i] = a[i] + b[i] using AVX-512 (512-bit, 16 float32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512AddVectorizedFloat32(dst, a, b []float32) {
 	n := len(dst)
 	i := 0
@@ -181,6 +201,8 @@ func avx512AddVectorizedFloat32(dst, a, b []float32) {
 	}
 }
 
+// avxSubVectorizedFloat32 computes dst[i] = a[i] - b[i] using AVX (256-bit, 8 float32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avxSubVectorizedFloat32(dst, a, b []float32) {
 	n := len(dst)
 	i := 0
@@ -195,6 +217,8 @@ func avxSubVectorizedFloat32(dst, a, b []float32) {
 	}
 }
 
+// avx512SubVectorizedFloat32 computes dst[i] = a[i] - b[i] using AVX-512 (512-bit, 16 float32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512SubVectorizedFloat32(dst, a, b []float32) {
 	n := len(dst)
 	i := 0
@@ -209,6 +233,8 @@ func avx512SubVectorizedFloat32(dst, a, b []float32) {
 	}
 }
 
+// avxMulVectorizedFloat32 computes dst[i] = a[i] * b[i] using AVX (256-bit, 8 float32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avxMulVectorizedFloat32(dst, a, b []float32) {
 	n := len(dst)
 	i := 0
@@ -223,6 +249,8 @@ func avxMulVectorizedFloat32(dst, a, b []float32) {
 	}
 }
 
+// avx512MulVectorizedFloat32 computes dst[i] = a[i] * b[i] using AVX-512 (512-bit, 16 float32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512MulVectorizedFloat32(dst, a, b []float32) {
 	n := len(dst)
 	i := 0
@@ -237,6 +265,8 @@ func avx512MulVectorizedFloat32(dst, a, b []float32) {
 	}
 }
 
+// avxDivVectorizedFloat32 computes dst[i] = a[i] / b[i] using AVX (256-bit, 8 float32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avxDivVectorizedFloat32(dst, a, b []float32) {
 	n := len(dst)
 	i := 0
@@ -251,6 +281,8 @@ func avxDivVectorizedFloat32(dst, a, b []float32) {
 	}
 }
 
+// avx512DivVectorizedFloat32 computes dst[i] = a[i] / b[i] using AVX-512 (512-bit, 16 float32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512DivVectorizedFloat32(dst, a, b []float32) {
 	n := len(dst)
 	i := 0

--- a/internal/backend/cpu/ops_float32_simd_stub.go
+++ b/internal/backend/cpu/ops_float32_simd_stub.go
@@ -1,0 +1,16 @@
+//go:build !amd64 || !goexperiment.simd
+
+package cpu
+
+// These functions are nil when SIMD is unavailable (non-amd64 or built
+// without GOEXPERIMENT=simd).  They fall back to the scalar
+// loop when nil.
+var simdAddInplaceFloat32 func(a, b []float32)
+var simdSubInplaceFloat32 func(a, b []float32)
+var simdMulInplaceFloat32 func(a, b []float32)
+var simdDivInplaceFloat32 func(a, b []float32)
+
+var simdAddVectorizedFloat32 func(dst, a, b []float32)
+var simdSubVectorizedFloat32 func(dst, a, b []float32)
+var simdMulVectorizedFloat32 func(dst, a, b []float32)
+var simdDivVectorizedFloat32 func(dst, a, b []float32)

--- a/internal/backend/cpu/ops_float32_simd_test.go
+++ b/internal/backend/cpu/ops_float32_simd_test.go
@@ -36,7 +36,7 @@ func BenchmarkAddInplaceF32_Scalar(b *testing.B) {
 // BenchmarkAddInplaceF32_SIMD benchmarks a[i] += b[i] using the SIMD implementation.
 func BenchmarkAddInplaceF32_SIMD(b *testing.B) {
 	if simdAddInplaceFloat32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -63,7 +63,7 @@ func BenchmarkSubInplaceF32_Scalar(b *testing.B) {
 // BenchmarkSubInplaceF32_SIMD benchmarks a[i] -= b[i] using the SIMD implementation.
 func BenchmarkSubInplaceF32_SIMD(b *testing.B) {
 	if simdSubInplaceFloat32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -90,7 +90,7 @@ func BenchmarkMulInplaceF32_Scalar(b *testing.B) {
 // BenchmarkMulInplaceF32_SIMD benchmarks a[i] *= b[i] using the SIMD implementation.
 func BenchmarkMulInplaceF32_SIMD(b *testing.B) {
 	if simdMulInplaceFloat32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -117,7 +117,7 @@ func BenchmarkDivInplaceF32_Scalar(b *testing.B) {
 // BenchmarkDivInplaceF32_SIMD benchmarks a[i] /= b[i] using the SIMD implementation.
 func BenchmarkDivInplaceF32_SIMD(b *testing.B) {
 	if simdDivInplaceFloat32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -145,7 +145,7 @@ func BenchmarkAddVectorizedF32_Scalar(b *testing.B) {
 // BenchmarkAddVectorizedF32_SIMD benchmarks dst[i] = a[i] + b[i] using the SIMD implementation.
 func BenchmarkAddVectorizedF32_SIMD(b *testing.B) {
 	if simdAddVectorizedFloat32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -174,7 +174,7 @@ func BenchmarkSubVectorizedF32_Scalar(b *testing.B) {
 // BenchmarkSubVectorizedF32_SIMD benchmarks dst[i] = a[i] - b[i] using the SIMD implementation.
 func BenchmarkSubVectorizedF32_SIMD(b *testing.B) {
 	if simdSubVectorizedFloat32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -203,7 +203,7 @@ func BenchmarkMulVectorizedF32_Scalar(b *testing.B) {
 // BenchmarkMulVectorizedF32_SIMD benchmarks dst[i] = a[i] * b[i] using the SIMD implementation.
 func BenchmarkMulVectorizedF32_SIMD(b *testing.B) {
 	if simdMulVectorizedFloat32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -232,7 +232,7 @@ func BenchmarkDivVectorizedF32_Scalar(b *testing.B) {
 // BenchmarkDivVectorizedF32_SIMD benchmarks dst[i] = a[i] / b[i] using the SIMD implementation.
 func BenchmarkDivVectorizedF32_SIMD(b *testing.B) {
 	if simdDivVectorizedFloat32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()

--- a/internal/backend/cpu/ops_float32_simd_test.go
+++ b/internal/backend/cpu/ops_float32_simd_test.go
@@ -10,10 +10,10 @@ func createRandomFloat32Slices() ([]float32, []float32) {
 	bSlice := make([]float32, 1024)
 	rng := rand.New(rand.NewSource(0))
 	for i := range aSlice {
-		aSlice[i] = rng.Float32()
+		aSlice[i] = rng.Float32()*2 - 1
 	}
 	for i := range bSlice {
-		bSlice[i] = rng.Float32()
+		bSlice[i] = rng.Float32()*2 - 1
 	}
 	return aSlice, bSlice
 }

--- a/internal/backend/cpu/ops_float32_simd_test.go
+++ b/internal/backend/cpu/ops_float32_simd_test.go
@@ -1,0 +1,227 @@
+package cpu
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func createRandomFloat32Slices() ([]float32, []float32) {
+	aSlice := make([]float32, 1024)
+	bSlice := make([]float32, 1024)
+	rng := rand.New(rand.NewSource(0))
+	for i := range aSlice {
+		aSlice[i] = rng.Float32()
+	}
+	for i := range bSlice {
+		bSlice[i] = rng.Float32()
+	}
+	return aSlice, bSlice
+}
+
+func BenchmarkAddInplaceF32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat32Slices()
+
+	saved := simdAddInplaceFloat32
+	simdAddInplaceFloat32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		addInplaceFloat32(aSlice, bSlice)
+	}
+	simdAddInplaceFloat32 = saved
+}
+
+func BenchmarkAddInplaceF32_SIMD(b *testing.B) {
+	if simdAddInplaceFloat32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat32Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		addInplaceFloat32(aSlice, bSlice)
+	}
+}
+
+func BenchmarkSubInplaceF32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat32Slices()
+
+	saved := simdSubInplaceFloat32
+	simdSubInplaceFloat32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		subInplaceFloat32(aSlice, bSlice)
+	}
+	simdSubInplaceFloat32 = saved
+}
+
+func BenchmarkSubInplaceF32_SIMD(b *testing.B) {
+	if simdSubInplaceFloat32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat32Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		subInplaceFloat32(aSlice, bSlice)
+	}
+}
+
+func BenchmarkMulInplaceF32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat32Slices()
+
+	saved := simdMulInplaceFloat32
+	simdMulInplaceFloat32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		mulInplaceFloat32(aSlice, bSlice)
+	}
+	simdMulInplaceFloat32 = saved
+}
+
+func BenchmarkMulInplaceF32_SIMD(b *testing.B) {
+	if simdMulInplaceFloat32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat32Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		mulInplaceFloat32(aSlice, bSlice)
+	}
+}
+
+func BenchmarkDivInplaceF32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat32Slices()
+
+	saved := simdDivInplaceFloat32
+	simdDivInplaceFloat32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		divInplaceFloat32(aSlice, bSlice)
+	}
+	simdDivInplaceFloat32 = saved
+}
+
+func BenchmarkDivInplaceF32_SIMD(b *testing.B) {
+	if simdDivInplaceFloat32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat32Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		divInplaceFloat32(aSlice, bSlice)
+	}
+}
+
+func BenchmarkAddVectorizedF32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat32Slices()
+	dst := make([]float32, len(aSlice))
+
+	saved := simdAddVectorizedFloat32
+	simdAddVectorizedFloat32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		addVectorizedFloat32(dst, aSlice, bSlice)
+	}
+	simdAddVectorizedFloat32 = saved
+}
+
+func BenchmarkAddVectorizedF32_SIMD(b *testing.B) {
+	if simdAddVectorizedFloat32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat32Slices()
+	dst := make([]float32, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		addVectorizedFloat32(dst, aSlice, bSlice)
+	}
+}
+
+func BenchmarkSubVectorizedF32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat32Slices()
+	dst := make([]float32, len(aSlice))
+
+	saved := simdSubVectorizedFloat32
+	simdSubVectorizedFloat32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		subVectorizedFloat32(dst, aSlice, bSlice)
+	}
+	simdSubVectorizedFloat32 = saved
+}
+
+func BenchmarkSubVectorizedF32_SIMD(b *testing.B) {
+	if simdSubVectorizedFloat32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat32Slices()
+	dst := make([]float32, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		subVectorizedFloat32(dst, aSlice, bSlice)
+	}
+}
+
+func BenchmarkMulVectorizedF32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat32Slices()
+	dst := make([]float32, len(aSlice))
+
+	saved := simdMulVectorizedFloat32
+	simdMulVectorizedFloat32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		mulVectorizedFloat32(dst, aSlice, bSlice)
+	}
+	simdMulVectorizedFloat32 = saved
+}
+
+func BenchmarkMulVectorizedF32_SIMD(b *testing.B) {
+	if simdMulVectorizedFloat32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat32Slices()
+	dst := make([]float32, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		mulVectorizedFloat32(dst, aSlice, bSlice)
+	}
+}
+
+func BenchmarkDivVectorizedF32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat32Slices()
+	dst := make([]float32, len(aSlice))
+
+	saved := simdDivVectorizedFloat32
+	simdDivVectorizedFloat32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		divVectorizedFloat32(dst, aSlice, bSlice)
+	}
+	simdDivVectorizedFloat32 = saved
+}
+
+func BenchmarkDivVectorizedF32_SIMD(b *testing.B) {
+	if simdDivVectorizedFloat32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat32Slices()
+	dst := make([]float32, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		divVectorizedFloat32(dst, aSlice, bSlice)
+	}
+}

--- a/internal/backend/cpu/ops_float32_simd_test.go
+++ b/internal/backend/cpu/ops_float32_simd_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+// createRandomFloat32Slices returns two 1024-element slices filled with
+// random float32 values in [-1, 1), suitable for benchmarking element-wise ops.
 func createRandomFloat32Slices() ([]float32, []float32) {
 	aSlice := make([]float32, 1024)
 	bSlice := make([]float32, 1024)
@@ -18,6 +20,7 @@ func createRandomFloat32Slices() ([]float32, []float32) {
 	return aSlice, bSlice
 }
 
+// BenchmarkAddInplaceF32_Scalar benchmarks a[i] += b[i] using the scalar fallback.
 func BenchmarkAddInplaceF32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat32Slices()
 
@@ -30,9 +33,10 @@ func BenchmarkAddInplaceF32_Scalar(b *testing.B) {
 	simdAddInplaceFloat32 = saved
 }
 
+// BenchmarkAddInplaceF32_SIMD benchmarks a[i] += b[i] using the SIMD implementation.
 func BenchmarkAddInplaceF32_SIMD(b *testing.B) {
 	if simdAddInplaceFloat32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -43,6 +47,7 @@ func BenchmarkAddInplaceF32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkSubInplaceF32_Scalar benchmarks a[i] -= b[i] using the scalar fallback.
 func BenchmarkSubInplaceF32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat32Slices()
 
@@ -55,9 +60,10 @@ func BenchmarkSubInplaceF32_Scalar(b *testing.B) {
 	simdSubInplaceFloat32 = saved
 }
 
+// BenchmarkSubInplaceF32_SIMD benchmarks a[i] -= b[i] using the SIMD implementation.
 func BenchmarkSubInplaceF32_SIMD(b *testing.B) {
 	if simdSubInplaceFloat32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -68,6 +74,7 @@ func BenchmarkSubInplaceF32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkMulInplaceF32_Scalar benchmarks a[i] *= b[i] using the scalar fallback.
 func BenchmarkMulInplaceF32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat32Slices()
 
@@ -80,9 +87,10 @@ func BenchmarkMulInplaceF32_Scalar(b *testing.B) {
 	simdMulInplaceFloat32 = saved
 }
 
+// BenchmarkMulInplaceF32_SIMD benchmarks a[i] *= b[i] using the SIMD implementation.
 func BenchmarkMulInplaceF32_SIMD(b *testing.B) {
 	if simdMulInplaceFloat32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -93,6 +101,7 @@ func BenchmarkMulInplaceF32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkDivInplaceF32_Scalar benchmarks a[i] /= b[i] using the scalar fallback.
 func BenchmarkDivInplaceF32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat32Slices()
 
@@ -105,9 +114,10 @@ func BenchmarkDivInplaceF32_Scalar(b *testing.B) {
 	simdDivInplaceFloat32 = saved
 }
 
+// BenchmarkDivInplaceF32_SIMD benchmarks a[i] /= b[i] using the SIMD implementation.
 func BenchmarkDivInplaceF32_SIMD(b *testing.B) {
 	if simdDivInplaceFloat32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -118,6 +128,7 @@ func BenchmarkDivInplaceF32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkAddVectorizedF32_Scalar benchmarks dst[i] = a[i] + b[i] using the scalar fallback.
 func BenchmarkAddVectorizedF32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat32Slices()
 	dst := make([]float32, len(aSlice))
@@ -131,9 +142,10 @@ func BenchmarkAddVectorizedF32_Scalar(b *testing.B) {
 	simdAddVectorizedFloat32 = saved
 }
 
+// BenchmarkAddVectorizedF32_SIMD benchmarks dst[i] = a[i] + b[i] using the SIMD implementation.
 func BenchmarkAddVectorizedF32_SIMD(b *testing.B) {
 	if simdAddVectorizedFloat32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -145,6 +157,7 @@ func BenchmarkAddVectorizedF32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkSubVectorizedF32_Scalar benchmarks dst[i] = a[i] - b[i] using the scalar fallback.
 func BenchmarkSubVectorizedF32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat32Slices()
 	dst := make([]float32, len(aSlice))
@@ -158,9 +171,10 @@ func BenchmarkSubVectorizedF32_Scalar(b *testing.B) {
 	simdSubVectorizedFloat32 = saved
 }
 
+// BenchmarkSubVectorizedF32_SIMD benchmarks dst[i] = a[i] - b[i] using the SIMD implementation.
 func BenchmarkSubVectorizedF32_SIMD(b *testing.B) {
 	if simdSubVectorizedFloat32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -172,6 +186,7 @@ func BenchmarkSubVectorizedF32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkMulVectorizedF32_Scalar benchmarks dst[i] = a[i] * b[i] using the scalar fallback.
 func BenchmarkMulVectorizedF32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat32Slices()
 	dst := make([]float32, len(aSlice))
@@ -185,9 +200,10 @@ func BenchmarkMulVectorizedF32_Scalar(b *testing.B) {
 	simdMulVectorizedFloat32 = saved
 }
 
+// BenchmarkMulVectorizedF32_SIMD benchmarks dst[i] = a[i] * b[i] using the SIMD implementation.
 func BenchmarkMulVectorizedF32_SIMD(b *testing.B) {
 	if simdMulVectorizedFloat32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()
@@ -199,6 +215,7 @@ func BenchmarkMulVectorizedF32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkDivVectorizedF32_Scalar benchmarks dst[i] = a[i] / b[i] using the scalar fallback.
 func BenchmarkDivVectorizedF32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat32Slices()
 	dst := make([]float32, len(aSlice))
@@ -212,9 +229,10 @@ func BenchmarkDivVectorizedF32_Scalar(b *testing.B) {
 	simdDivVectorizedFloat32 = saved
 }
 
+// BenchmarkDivVectorizedF32_SIMD benchmarks dst[i] = a[i] / b[i] using the SIMD implementation.
 func BenchmarkDivVectorizedF32_SIMD(b *testing.B) {
 	if simdDivVectorizedFloat32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat32Slices()

--- a/internal/backend/cpu/ops_float64.go
+++ b/internal/backend/cpu/ops_float64.go
@@ -7,48 +7,80 @@ import (
 // Float64 operations follow the same pattern as float32
 
 func addInplaceFloat64(a, b []float64) {
+	if simdAddInplaceFloat64 != nil {
+		simdAddInplaceFloat64(a, b)
+		return
+	}
 	for i := range a {
 		a[i] += b[i]
 	}
 }
 
 func subInplaceFloat64(a, b []float64) {
+	if simdSubInplaceFloat64 != nil {
+		simdSubInplaceFloat64(a, b)
+		return
+	}
 	for i := range a {
 		a[i] -= b[i]
 	}
 }
 
 func mulInplaceFloat64(a, b []float64) {
+	if simdMulInplaceFloat64 != nil {
+		simdMulInplaceFloat64(a, b)
+		return
+	}
 	for i := range a {
 		a[i] *= b[i]
 	}
 }
 
 func divInplaceFloat64(a, b []float64) {
+	if simdDivInplaceFloat64 != nil {
+		simdDivInplaceFloat64(a, b)
+		return
+	}
 	for i := range a {
 		a[i] /= b[i]
 	}
 }
 
 func addVectorizedFloat64(dst, a, b []float64) {
+	if simdAddVectorizedFloat64 != nil {
+		simdAddVectorizedFloat64(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] + b[i]
 	}
 }
 
 func subVectorizedFloat64(dst, a, b []float64) {
+	if simdSubVectorizedFloat64 != nil {
+		simdSubVectorizedFloat64(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] - b[i]
 	}
 }
 
 func mulVectorizedFloat64(dst, a, b []float64) {
+	if simdMulVectorizedFloat64 != nil {
+		simdMulVectorizedFloat64(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] * b[i]
 	}
 }
 
 func divVectorizedFloat64(dst, a, b []float64) {
+	if simdDivVectorizedFloat64 != nil {
+		simdDivVectorizedFloat64(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] / b[i]
 	}

--- a/internal/backend/cpu/ops_float64_simd_amd64.go
+++ b/internal/backend/cpu/ops_float64_simd_amd64.go
@@ -22,6 +22,11 @@ func init() {
 		simdSubInplaceFloat64 = avxSubInplaceFloat64
 		simdMulInplaceFloat64 = avxMulInplaceFloat64
 		simdDivInplaceFloat64 = avxDivInplaceFloat64
+
+		simdAddVectorizedFloat64 = avxAddVectorizedFloat64
+		simdSubVectorizedFloat64 = avxSubVectorizedFloat64
+		simdMulVectorizedFloat64 = avxMulVectorizedFloat64
+		simdDivVectorizedFloat64 = avxDivVectorizedFloat64
 	}
 
 	if archsimd.X86.AVX512() {
@@ -149,6 +154,20 @@ func avx512DivInplaceFloat64(a, b []float64) {
 	}
 }
 
+func avxAddVectorizedFloat64(dst, a, b []float64) {
+	n := len(dst)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadFloat64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadFloat64x4Slice(b[i : i+4])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(dst[i : i+4])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] + b[i]
+	}
+}
+
 func avx512AddVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0
@@ -160,6 +179,20 @@ func avx512AddVectorizedFloat64(dst, a, b []float64) {
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] + b[i]
+	}
+}
+
+func avxSubVectorizedFloat64(dst, a, b []float64) {
+	n := len(dst)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadFloat64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadFloat64x4Slice(b[i : i+4])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+4])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] - b[i]
 	}
 }
 
@@ -177,6 +210,20 @@ func avx512SubVectorizedFloat64(dst, a, b []float64) {
 	}
 }
 
+func avxMulVectorizedFloat64(dst, a, b []float64) {
+	n := len(dst)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadFloat64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadFloat64x4Slice(b[i : i+4])
+		subLoaded := aLoaded.Mul(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+4])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] * b[i]
+	}
+}
+
 func avx512MulVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0
@@ -190,7 +237,19 @@ func avx512MulVectorizedFloat64(dst, a, b []float64) {
 		dst[i] = a[i] * b[i]
 	}
 }
-
+func avxDivVectorizedFloat64(dst, a, b []float64) {
+	n := len(dst)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadFloat64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadFloat64x4Slice(b[i : i+4])
+		subLoaded := aLoaded.Div(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+4])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] / b[i]
+	}
+}
 func avx512DivVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0

--- a/internal/backend/cpu/ops_float64_simd_amd64.go
+++ b/internal/backend/cpu/ops_float64_simd_amd64.go
@@ -42,6 +42,8 @@ func init() {
 	}
 }
 
+// avxAddInplaceFloat64 computes a[i] += b[i] using AVX (256-bit, 4 float64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avxAddInplaceFloat64(a, b []float64) {
 	n := len(a)
 	i := 0
@@ -56,6 +58,8 @@ func avxAddInplaceFloat64(a, b []float64) {
 	}
 }
 
+// avx512AddInplaceFloat64 computes a[i] += b[i] using AVX-512 (512-bit, 8 float64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512AddInplaceFloat64(a, b []float64) {
 	n := len(a)
 	i := 0
@@ -70,6 +74,8 @@ func avx512AddInplaceFloat64(a, b []float64) {
 	}
 }
 
+// avxSubInplaceFloat64 computes a[i] -= b[i] using AVX (256-bit, 4 float64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avxSubInplaceFloat64(a, b []float64) {
 	n := len(a)
 	i := 0
@@ -84,6 +90,8 @@ func avxSubInplaceFloat64(a, b []float64) {
 	}
 }
 
+// avx512SubInplaceFloat64 computes a[i] -= b[i] using AVX-512 (512-bit, 8 float64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512SubInplaceFloat64(a, b []float64) {
 	n := len(a)
 	i := 0
@@ -98,6 +106,8 @@ func avx512SubInplaceFloat64(a, b []float64) {
 	}
 }
 
+// avxMulInplaceFloat64 computes a[i] *= b[i] using AVX (256-bit, 4 float64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avxMulInplaceFloat64(a, b []float64) {
 	n := len(a)
 	i := 0
@@ -112,6 +122,8 @@ func avxMulInplaceFloat64(a, b []float64) {
 	}
 }
 
+// avx512MulInplaceFloat64 computes a[i] *= b[i] using AVX-512 (512-bit, 8 float64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512MulInplaceFloat64(a, b []float64) {
 	n := len(a)
 	i := 0
@@ -126,6 +138,8 @@ func avx512MulInplaceFloat64(a, b []float64) {
 	}
 }
 
+// avxDivInplaceFloat64 computes a[i] /= b[i] using AVX (256-bit, 4 float64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avxDivInplaceFloat64(a, b []float64) {
 	n := len(a)
 	i := 0
@@ -140,6 +154,8 @@ func avxDivInplaceFloat64(a, b []float64) {
 	}
 }
 
+// avx512DivInplaceFloat64 computes a[i] /= b[i] using AVX-512 (512-bit, 8 float64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512DivInplaceFloat64(a, b []float64) {
 	n := len(a)
 	i := 0
@@ -154,6 +170,8 @@ func avx512DivInplaceFloat64(a, b []float64) {
 	}
 }
 
+// avxAddVectorizedFloat64 computes dst[i] = a[i] + b[i] using AVX (256-bit, 4 float64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avxAddVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0
@@ -168,6 +186,8 @@ func avxAddVectorizedFloat64(dst, a, b []float64) {
 	}
 }
 
+// avx512AddVectorizedFloat64 computes dst[i] = a[i] + b[i] using AVX-512 (512-bit, 8 float64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512AddVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0
@@ -182,6 +202,8 @@ func avx512AddVectorizedFloat64(dst, a, b []float64) {
 	}
 }
 
+// avxSubVectorizedFloat64 computes dst[i] = a[i] - b[i] using AVX (256-bit, 4 float64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avxSubVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0
@@ -196,6 +218,8 @@ func avxSubVectorizedFloat64(dst, a, b []float64) {
 	}
 }
 
+// avx512SubVectorizedFloat64 computes dst[i] = a[i] - b[i] using AVX-512 (512-bit, 8 float64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512SubVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0
@@ -210,6 +234,8 @@ func avx512SubVectorizedFloat64(dst, a, b []float64) {
 	}
 }
 
+// avxMulVectorizedFloat64 computes dst[i] = a[i] * b[i] using AVX (256-bit, 4 float64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avxMulVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0
@@ -224,6 +250,8 @@ func avxMulVectorizedFloat64(dst, a, b []float64) {
 	}
 }
 
+// avx512MulVectorizedFloat64 computes dst[i] = a[i] * b[i] using AVX-512 (512-bit, 8 float64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512MulVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0
@@ -237,6 +265,8 @@ func avx512MulVectorizedFloat64(dst, a, b []float64) {
 		dst[i] = a[i] * b[i]
 	}
 }
+// avxDivVectorizedFloat64 computes dst[i] = a[i] / b[i] using AVX (256-bit, 4 float64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avxDivVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0
@@ -250,6 +280,8 @@ func avxDivVectorizedFloat64(dst, a, b []float64) {
 		dst[i] = a[i] / b[i]
 	}
 }
+// avx512DivVectorizedFloat64 computes dst[i] = a[i] / b[i] using AVX-512 (512-bit, 8 float64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512DivVectorizedFloat64(dst, a, b []float64) {
 	n := len(dst)
 	i := 0

--- a/internal/backend/cpu/ops_float64_simd_amd64.go
+++ b/internal/backend/cpu/ops_float64_simd_amd64.go
@@ -1,0 +1,206 @@
+//go:build amd64 && goexperiment.simd
+
+package cpu
+
+import "simd/archsimd"
+
+// Declared here for amd64+goexperiment.simd builds; the stub file provides the
+// same declaration for all other platforms/configurations.
+var simdAddInplaceFloat64 func(a, b []float64)
+var simdSubInplaceFloat64 func(a, b []float64)
+var simdMulInplaceFloat64 func(a, b []float64)
+var simdDivInplaceFloat64 func(a, b []float64)
+
+var simdAddVectorizedFloat64 func(dst, a, b []float64)
+var simdSubVectorizedFloat64 func(dst, a, b []float64)
+var simdMulVectorizedFloat64 func(dst, a, b []float64)
+var simdDivVectorizedFloat64 func(dst, a, b []float64)
+
+func init() {
+	if archsimd.X86.AVX() {
+		simdAddInplaceFloat64 = avxAddInplaceFloat64
+		simdSubInplaceFloat64 = avxSubInplaceFloat64
+		simdMulInplaceFloat64 = avxMulInplaceFloat64
+		simdDivInplaceFloat64 = avxDivInplaceFloat64
+	}
+
+	if archsimd.X86.AVX512() {
+		simdAddInplaceFloat64 = avx512AddInplaceFloat64
+		simdSubInplaceFloat64 = avx512SubInplaceFloat64
+		simdMulInplaceFloat64 = avx512MulInplaceFloat64
+		simdDivInplaceFloat64 = avx512DivInplaceFloat64
+
+		simdAddVectorizedFloat64 = avx512AddVectorizedFloat64
+		simdSubVectorizedFloat64 = avx512SubVectorizedFloat64
+		simdMulVectorizedFloat64 = avx512MulVectorizedFloat64
+		simdDivVectorizedFloat64 = avx512DivVectorizedFloat64
+	}
+}
+
+func avxAddInplaceFloat64(a, b []float64) {
+	n := len(a)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadFloat64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadFloat64x4Slice(b[i : i+4])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(a[i : i+4])
+	}
+	for ; i < n; i++ {
+		a[i] += b[i]
+	}
+}
+
+func avx512AddInplaceFloat64(a, b []float64) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat64x8Slice(b[i : i+8])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] += b[i]
+	}
+}
+
+func avxSubInplaceFloat64(a, b []float64) {
+	n := len(a)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadFloat64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadFloat64x4Slice(b[i : i+4])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(a[i : i+4])
+	}
+	for ; i < n; i++ {
+		a[i] -= b[i]
+	}
+}
+
+func avx512SubInplaceFloat64(a, b []float64) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat64x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] -= b[i]
+	}
+}
+
+func avxMulInplaceFloat64(a, b []float64) {
+	n := len(a)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadFloat64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadFloat64x4Slice(b[i : i+4])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(a[i : i+4])
+	}
+	for ; i < n; i++ {
+		a[i] *= b[i]
+	}
+}
+
+func avx512MulInplaceFloat64(a, b []float64) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat64x8Slice(b[i : i+8])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] *= b[i]
+	}
+}
+
+func avxDivInplaceFloat64(a, b []float64) {
+	n := len(a)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadFloat64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadFloat64x4Slice(b[i : i+4])
+		divLoaded := aLoaded.Div(bLoaded)
+		divLoaded.StoreSlice(a[i : i+4])
+	}
+	for ; i < n; i++ {
+		a[i] /= b[i]
+	}
+}
+
+func avx512DivInplaceFloat64(a, b []float64) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat64x8Slice(b[i : i+8])
+		divLoaded := aLoaded.Div(bLoaded)
+		divLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] /= b[i]
+	}
+}
+
+func avx512AddVectorizedFloat64(dst, a, b []float64) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat64x8Slice(b[i : i+8])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] + b[i]
+	}
+}
+
+func avx512SubVectorizedFloat64(dst, a, b []float64) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat64x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] - b[i]
+	}
+}
+
+func avx512MulVectorizedFloat64(dst, a, b []float64) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat64x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Mul(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] * b[i]
+	}
+}
+
+func avx512DivVectorizedFloat64(dst, a, b []float64) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadFloat64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadFloat64x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Div(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] / b[i]
+	}
+}

--- a/internal/backend/cpu/ops_float64_simd_amd64.go
+++ b/internal/backend/cpu/ops_float64_simd_amd64.go
@@ -242,8 +242,8 @@ func avxMulVectorizedFloat64(dst, a, b []float64) {
 	for ; i+4 <= n; i += 4 {
 		aLoaded := archsimd.LoadFloat64x4Slice(a[i : i+4])
 		bLoaded := archsimd.LoadFloat64x4Slice(b[i : i+4])
-		subLoaded := aLoaded.Mul(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+4])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(dst[i : i+4])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] * b[i]
@@ -258,13 +258,14 @@ func avx512MulVectorizedFloat64(dst, a, b []float64) {
 	for ; i+8 <= n; i += 8 {
 		aLoaded := archsimd.LoadFloat64x8Slice(a[i : i+8])
 		bLoaded := archsimd.LoadFloat64x8Slice(b[i : i+8])
-		subLoaded := aLoaded.Mul(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+8])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(dst[i : i+8])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] * b[i]
 	}
 }
+
 // avxDivVectorizedFloat64 computes dst[i] = a[i] / b[i] using AVX (256-bit, 4 float64/vector).
 // Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avxDivVectorizedFloat64(dst, a, b []float64) {
@@ -273,13 +274,14 @@ func avxDivVectorizedFloat64(dst, a, b []float64) {
 	for ; i+4 <= n; i += 4 {
 		aLoaded := archsimd.LoadFloat64x4Slice(a[i : i+4])
 		bLoaded := archsimd.LoadFloat64x4Slice(b[i : i+4])
-		subLoaded := aLoaded.Div(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+4])
+		divLoaded := aLoaded.Div(bLoaded)
+		divLoaded.StoreSlice(dst[i : i+4])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] / b[i]
 	}
 }
+
 // avx512DivVectorizedFloat64 computes dst[i] = a[i] / b[i] using AVX-512 (512-bit, 8 float64/vector).
 // Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512DivVectorizedFloat64(dst, a, b []float64) {
@@ -288,8 +290,8 @@ func avx512DivVectorizedFloat64(dst, a, b []float64) {
 	for ; i+8 <= n; i += 8 {
 		aLoaded := archsimd.LoadFloat64x8Slice(a[i : i+8])
 		bLoaded := archsimd.LoadFloat64x8Slice(b[i : i+8])
-		subLoaded := aLoaded.Div(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+8])
+		divLoaded := aLoaded.Div(bLoaded)
+		divLoaded.StoreSlice(dst[i : i+8])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] / b[i]

--- a/internal/backend/cpu/ops_float64_simd_stub.go
+++ b/internal/backend/cpu/ops_float64_simd_stub.go
@@ -1,0 +1,16 @@
+//go:build !amd64 || !goexperiment.simd
+
+package cpu
+
+// These functions are nil when SIMD is unavailable (non-amd64 or built
+// without GOEXPERIMENT=simd).  They fall back to the scalar
+// loop when nil.
+var simdAddInplaceFloat64 func(a, b []float64)
+var simdSubInplaceFloat64 func(a, b []float64)
+var simdMulInplaceFloat64 func(a, b []float64)
+var simdDivInplaceFloat64 func(a, b []float64)
+
+var simdAddVectorizedFloat64 func(dst, a, b []float64)
+var simdSubVectorizedFloat64 func(dst, a, b []float64)
+var simdMulVectorizedFloat64 func(dst, a, b []float64)
+var simdDivVectorizedFloat64 func(dst, a, b []float64)

--- a/internal/backend/cpu/ops_float64_simd_test.go
+++ b/internal/backend/cpu/ops_float64_simd_test.go
@@ -10,10 +10,10 @@ func createRandomFloat64Slices() ([]float64, []float64) {
 	bSlice := make([]float64, 1024)
 	rng := rand.New(rand.NewSource(0))
 	for i := range aSlice {
-		aSlice[i] = rng.Float64()
+		aSlice[i] = rng.Float64()*2 - 1
 	}
 	for i := range bSlice {
-		bSlice[i] = rng.Float64()
+		bSlice[i] = rng.Float64()*2 - 1
 	}
 	return aSlice, bSlice
 }

--- a/internal/backend/cpu/ops_float64_simd_test.go
+++ b/internal/backend/cpu/ops_float64_simd_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+// createRandomFloat64Slices returns two 1024-element slices filled with
+// random float64 values in [-1, 1), suitable for benchmarking element-wise ops.
 func createRandomFloat64Slices() ([]float64, []float64) {
 	aSlice := make([]float64, 1024)
 	bSlice := make([]float64, 1024)
@@ -18,6 +20,7 @@ func createRandomFloat64Slices() ([]float64, []float64) {
 	return aSlice, bSlice
 }
 
+// BenchmarkAddInplaceF64_Scalar benchmarks a[i] += b[i] using the scalar fallback.
 func BenchmarkAddInplaceF64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat64Slices()
 
@@ -30,9 +33,10 @@ func BenchmarkAddInplaceF64_Scalar(b *testing.B) {
 	simdAddInplaceFloat64 = saved
 }
 
+// BenchmarkAddInplaceF64_SIMD benchmarks a[i] += b[i] using the SIMD implementation.
 func BenchmarkAddInplaceF64_SIMD(b *testing.B) {
 	if simdAddInplaceFloat64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -43,6 +47,7 @@ func BenchmarkAddInplaceF64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkSubInplaceF64_Scalar benchmarks a[i] -= b[i] using the scalar fallback.
 func BenchmarkSubInplaceF64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat64Slices()
 
@@ -55,9 +60,10 @@ func BenchmarkSubInplaceF64_Scalar(b *testing.B) {
 	simdSubInplaceFloat64 = saved
 }
 
+// BenchmarkSubInplaceF64_SIMD benchmarks a[i] -= b[i] using the SIMD implementation.
 func BenchmarkSubInplaceF64_SIMD(b *testing.B) {
 	if simdSubInplaceFloat64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -68,6 +74,7 @@ func BenchmarkSubInplaceF64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkMulInplaceF64_Scalar benchmarks a[i] *= b[i] using the scalar fallback.
 func BenchmarkMulInplaceF64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat64Slices()
 
@@ -80,9 +87,10 @@ func BenchmarkMulInplaceF64_Scalar(b *testing.B) {
 	simdMulInplaceFloat64 = saved
 }
 
+// BenchmarkMulInplaceF64_SIMD benchmarks a[i] *= b[i] using the SIMD implementation.
 func BenchmarkMulInplaceF64_SIMD(b *testing.B) {
 	if simdMulInplaceFloat64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -93,6 +101,7 @@ func BenchmarkMulInplaceF64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkDivInplaceF64_Scalar benchmarks a[i] /= b[i] using the scalar fallback.
 func BenchmarkDivInplaceF64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat64Slices()
 
@@ -105,9 +114,10 @@ func BenchmarkDivInplaceF64_Scalar(b *testing.B) {
 	simdDivInplaceFloat64 = saved
 }
 
+// BenchmarkDivInplaceF64_SIMD benchmarks a[i] /= b[i] using the SIMD implementation.
 func BenchmarkDivInplaceF64_SIMD(b *testing.B) {
 	if simdDivInplaceFloat64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -118,6 +128,7 @@ func BenchmarkDivInplaceF64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkAddVectorizedF64_Scalar benchmarks dst[i] = a[i] + b[i] using the scalar fallback.
 func BenchmarkAddVectorizedF64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat64Slices()
 	dst := make([]float64, len(aSlice))
@@ -131,9 +142,10 @@ func BenchmarkAddVectorizedF64_Scalar(b *testing.B) {
 	simdAddVectorizedFloat64 = saved
 }
 
+// BenchmarkAddVectorizedF64_SIMD benchmarks dst[i] = a[i] + b[i] using the SIMD implementation.
 func BenchmarkAddVectorizedF64_SIMD(b *testing.B) {
 	if simdAddVectorizedFloat64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -145,6 +157,7 @@ func BenchmarkAddVectorizedF64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkSubVectorizedF64_Scalar benchmarks dst[i] = a[i] - b[i] using the scalar fallback.
 func BenchmarkSubVectorizedF64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat64Slices()
 	dst := make([]float64, len(aSlice))
@@ -158,9 +171,10 @@ func BenchmarkSubVectorizedF64_Scalar(b *testing.B) {
 	simdSubVectorizedFloat64 = saved
 }
 
+// BenchmarkSubVectorizedF64_SIMD benchmarks dst[i] = a[i] - b[i] using the SIMD implementation.
 func BenchmarkSubVectorizedF64_SIMD(b *testing.B) {
 	if simdSubVectorizedFloat64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -172,6 +186,7 @@ func BenchmarkSubVectorizedF64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkMulVectorizedF64_Scalar benchmarks dst[i] = a[i] * b[i] using the scalar fallback.
 func BenchmarkMulVectorizedF64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat64Slices()
 	dst := make([]float64, len(aSlice))
@@ -185,9 +200,10 @@ func BenchmarkMulVectorizedF64_Scalar(b *testing.B) {
 	simdMulVectorizedFloat64 = saved
 }
 
+// BenchmarkMulVectorizedF64_SIMD benchmarks dst[i] = a[i] * b[i] using the SIMD implementation.
 func BenchmarkMulVectorizedF64_SIMD(b *testing.B) {
 	if simdMulVectorizedFloat64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -199,6 +215,7 @@ func BenchmarkMulVectorizedF64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkDivVectorizedF64_Scalar benchmarks dst[i] = a[i] / b[i] using the scalar fallback.
 func BenchmarkDivVectorizedF64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomFloat64Slices()
 	dst := make([]float64, len(aSlice))
@@ -212,9 +229,10 @@ func BenchmarkDivVectorizedF64_Scalar(b *testing.B) {
 	simdDivVectorizedFloat64 = saved
 }
 
+// BenchmarkDivVectorizedF64_SIMD benchmarks dst[i] = a[i] / b[i] using the SIMD implementation.
 func BenchmarkDivVectorizedF64_SIMD(b *testing.B) {
 	if simdDivVectorizedFloat64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()

--- a/internal/backend/cpu/ops_float64_simd_test.go
+++ b/internal/backend/cpu/ops_float64_simd_test.go
@@ -36,7 +36,7 @@ func BenchmarkAddInplaceF64_Scalar(b *testing.B) {
 // BenchmarkAddInplaceF64_SIMD benchmarks a[i] += b[i] using the SIMD implementation.
 func BenchmarkAddInplaceF64_SIMD(b *testing.B) {
 	if simdAddInplaceFloat64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -63,7 +63,7 @@ func BenchmarkSubInplaceF64_Scalar(b *testing.B) {
 // BenchmarkSubInplaceF64_SIMD benchmarks a[i] -= b[i] using the SIMD implementation.
 func BenchmarkSubInplaceF64_SIMD(b *testing.B) {
 	if simdSubInplaceFloat64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -90,7 +90,7 @@ func BenchmarkMulInplaceF64_Scalar(b *testing.B) {
 // BenchmarkMulInplaceF64_SIMD benchmarks a[i] *= b[i] using the SIMD implementation.
 func BenchmarkMulInplaceF64_SIMD(b *testing.B) {
 	if simdMulInplaceFloat64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -117,7 +117,7 @@ func BenchmarkDivInplaceF64_Scalar(b *testing.B) {
 // BenchmarkDivInplaceF64_SIMD benchmarks a[i] /= b[i] using the SIMD implementation.
 func BenchmarkDivInplaceF64_SIMD(b *testing.B) {
 	if simdDivInplaceFloat64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -145,7 +145,7 @@ func BenchmarkAddVectorizedF64_Scalar(b *testing.B) {
 // BenchmarkAddVectorizedF64_SIMD benchmarks dst[i] = a[i] + b[i] using the SIMD implementation.
 func BenchmarkAddVectorizedF64_SIMD(b *testing.B) {
 	if simdAddVectorizedFloat64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -174,7 +174,7 @@ func BenchmarkSubVectorizedF64_Scalar(b *testing.B) {
 // BenchmarkSubVectorizedF64_SIMD benchmarks dst[i] = a[i] - b[i] using the SIMD implementation.
 func BenchmarkSubVectorizedF64_SIMD(b *testing.B) {
 	if simdSubVectorizedFloat64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -203,7 +203,7 @@ func BenchmarkMulVectorizedF64_Scalar(b *testing.B) {
 // BenchmarkMulVectorizedF64_SIMD benchmarks dst[i] = a[i] * b[i] using the SIMD implementation.
 func BenchmarkMulVectorizedF64_SIMD(b *testing.B) {
 	if simdMulVectorizedFloat64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()
@@ -232,7 +232,7 @@ func BenchmarkDivVectorizedF64_Scalar(b *testing.B) {
 // BenchmarkDivVectorizedF64_SIMD benchmarks dst[i] = a[i] / b[i] using the SIMD implementation.
 func BenchmarkDivVectorizedF64_SIMD(b *testing.B) {
 	if simdDivVectorizedFloat64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomFloat64Slices()

--- a/internal/backend/cpu/ops_float64_simd_test.go
+++ b/internal/backend/cpu/ops_float64_simd_test.go
@@ -1,0 +1,227 @@
+package cpu
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func createRandomFloat64Slices() ([]float64, []float64) {
+	aSlice := make([]float64, 1024)
+	bSlice := make([]float64, 1024)
+	rng := rand.New(rand.NewSource(0))
+	for i := range aSlice {
+		aSlice[i] = rng.Float64()
+	}
+	for i := range bSlice {
+		bSlice[i] = rng.Float64()
+	}
+	return aSlice, bSlice
+}
+
+func BenchmarkAddInplaceF64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat64Slices()
+
+	saved := simdAddInplaceFloat64
+	simdAddInplaceFloat64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		addInplaceFloat64(aSlice, bSlice)
+	}
+	simdAddInplaceFloat64 = saved
+}
+
+func BenchmarkAddInplaceF64_SIMD(b *testing.B) {
+	if simdAddInplaceFloat64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat64Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		addInplaceFloat64(aSlice, bSlice)
+	}
+}
+
+func BenchmarkSubInplaceF64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat64Slices()
+
+	saved := simdSubInplaceFloat64
+	simdSubInplaceFloat64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		subInplaceFloat64(aSlice, bSlice)
+	}
+	simdSubInplaceFloat64 = saved
+}
+
+func BenchmarkSubInplaceF64_SIMD(b *testing.B) {
+	if simdSubInplaceFloat64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat64Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		subInplaceFloat64(aSlice, bSlice)
+	}
+}
+
+func BenchmarkMulInplaceF64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat64Slices()
+
+	saved := simdMulInplaceFloat64
+	simdMulInplaceFloat64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		mulInplaceFloat64(aSlice, bSlice)
+	}
+	simdMulInplaceFloat64 = saved
+}
+
+func BenchmarkMulInplaceF64_SIMD(b *testing.B) {
+	if simdMulInplaceFloat64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat64Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		mulInplaceFloat64(aSlice, bSlice)
+	}
+}
+
+func BenchmarkDivInplaceF64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat64Slices()
+
+	saved := simdDivInplaceFloat64
+	simdDivInplaceFloat64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		divInplaceFloat64(aSlice, bSlice)
+	}
+	simdDivInplaceFloat64 = saved
+}
+
+func BenchmarkDivInplaceF64_SIMD(b *testing.B) {
+	if simdDivInplaceFloat64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat64Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		divInplaceFloat64(aSlice, bSlice)
+	}
+}
+
+func BenchmarkAddVectorizedF64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat64Slices()
+	dst := make([]float64, len(aSlice))
+
+	saved := simdAddVectorizedFloat64
+	simdAddVectorizedFloat64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		addVectorizedFloat64(dst, aSlice, bSlice)
+	}
+	simdAddVectorizedFloat64 = saved
+}
+
+func BenchmarkAddVectorizedF64_SIMD(b *testing.B) {
+	if simdAddVectorizedFloat64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat64Slices()
+	dst := make([]float64, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		addVectorizedFloat64(dst, aSlice, bSlice)
+	}
+}
+
+func BenchmarkSubVectorizedF64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat64Slices()
+	dst := make([]float64, len(aSlice))
+
+	saved := simdSubVectorizedFloat64
+	simdSubVectorizedFloat64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		subVectorizedFloat64(dst, aSlice, bSlice)
+	}
+	simdSubVectorizedFloat64 = saved
+}
+
+func BenchmarkSubVectorizedF64_SIMD(b *testing.B) {
+	if simdSubVectorizedFloat64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat64Slices()
+	dst := make([]float64, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		subVectorizedFloat64(dst, aSlice, bSlice)
+	}
+}
+
+func BenchmarkMulVectorizedF64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat64Slices()
+	dst := make([]float64, len(aSlice))
+
+	saved := simdMulVectorizedFloat64
+	simdMulVectorizedFloat64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		mulVectorizedFloat64(dst, aSlice, bSlice)
+	}
+	simdMulVectorizedFloat64 = saved
+}
+
+func BenchmarkMulVectorizedF64_SIMD(b *testing.B) {
+	if simdMulVectorizedFloat64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat64Slices()
+	dst := make([]float64, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		mulVectorizedFloat64(dst, aSlice, bSlice)
+	}
+}
+
+func BenchmarkDivVectorizedF64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomFloat64Slices()
+	dst := make([]float64, len(aSlice))
+
+	saved := simdDivVectorizedFloat64
+	simdDivVectorizedFloat64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		divVectorizedFloat64(dst, aSlice, bSlice)
+	}
+	simdDivVectorizedFloat64 = saved
+}
+
+func BenchmarkDivVectorizedF64_SIMD(b *testing.B) {
+	if simdDivVectorizedFloat64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomFloat64Slices()
+	dst := make([]float64, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		divVectorizedFloat64(dst, aSlice, bSlice)
+	}
+}

--- a/internal/backend/cpu/ops_int.go
+++ b/internal/backend/cpu/ops_int.go
@@ -7,18 +7,30 @@ import (
 // Int32 operations
 
 func addInplaceInt32(a, b []int32) {
+	if simdAddInplaceInt32 != nil {
+		simdAddInplaceInt32(a, b)
+		return
+	}
 	for i := range a {
 		a[i] += b[i]
 	}
 }
 
 func subInplaceInt32(a, b []int32) {
+	if simdSubInplaceInt32 != nil {
+		simdSubInplaceInt32(a, b)
+		return
+	}
 	for i := range a {
 		a[i] -= b[i]
 	}
 }
 
 func mulInplaceInt32(a, b []int32) {
+	if simdMulInplaceInt32 != nil {
+		simdMulInplaceInt32(a, b)
+		return
+	}
 	for i := range a {
 		a[i] *= b[i]
 	}
@@ -31,18 +43,30 @@ func divInplaceInt32(a, b []int32) {
 }
 
 func addVectorizedInt32(dst, a, b []int32) {
+	if simdAddVectorizedInt32 != nil {
+		simdAddVectorizedInt32(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] + b[i]
 	}
 }
 
 func subVectorizedInt32(dst, a, b []int32) {
+	if simdSubVectorizedInt32 != nil {
+		simdSubVectorizedInt32(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] - b[i]
 	}
 }
 
 func mulVectorizedInt32(dst, a, b []int32) {
+	if simdMulVectorizedInt32 != nil {
+		simdMulVectorizedInt32(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] * b[i]
 	}
@@ -147,18 +171,30 @@ func transposeInt32(dst, src []int32, shape tensor.Shape, axes []int) {
 // Int64 operations
 
 func addInplaceInt64(a, b []int64) {
+	if simdAddInplaceInt64 != nil {
+		simdAddInplaceInt64(a, b)
+		return
+	}
 	for i := range a {
 		a[i] += b[i]
 	}
 }
 
 func subInplaceInt64(a, b []int64) {
+	if simdSubInplaceInt64 != nil {
+		simdSubInplaceInt64(a, b)
+		return
+	}
 	for i := range a {
 		a[i] -= b[i]
 	}
 }
 
 func mulInplaceInt64(a, b []int64) {
+	if simdMulInplaceInt64 != nil {
+		simdMulInplaceInt64(a, b)
+		return
+	}
 	for i := range a {
 		a[i] *= b[i]
 	}
@@ -171,18 +207,30 @@ func divInplaceInt64(a, b []int64) {
 }
 
 func addVectorizedInt64(dst, a, b []int64) {
+	if simdAddVectorizedInt64 != nil {
+		simdAddVectorizedInt64(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] + b[i]
 	}
 }
 
 func subVectorizedInt64(dst, a, b []int64) {
+	if simdSubVectorizedInt64 != nil {
+		simdSubVectorizedInt64(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] - b[i]
 	}
 }
 
 func mulVectorizedInt64(dst, a, b []int64) {
+	if simdMulVectorizedInt64 != nil {
+		simdMulVectorizedInt64(dst, a, b)
+		return
+	}
 	for i := range a {
 		dst[i] = a[i] * b[i]
 	}

--- a/internal/backend/cpu/ops_int32_simd_amd64.go
+++ b/internal/backend/cpu/ops_int32_simd_amd64.go
@@ -1,0 +1,204 @@
+//go:build amd64 && goexperiment.simd
+
+package cpu
+
+import "simd/archsimd"
+
+// Declared here for amd64+goexperiment.simd builds; the stub file provides the
+// same declaration for all other platforms/configurations.
+var simdAddInplaceInt32 func(a, b []int32)
+var simdSubInplaceInt32 func(a, b []int32)
+var simdMulInplaceInt32 func(a, b []int32)
+
+var simdAddVectorizedInt32 func(dst, a, b []int32)
+var simdSubVectorizedInt32 func(dst, a, b []int32)
+var simdMulVectorizedInt32 func(dst, a, b []int32)
+
+func init() {
+	if archsimd.X86.AVX2() {
+		simdAddInplaceInt32 = avx2AddInplaceInt32
+		simdSubInplaceInt32 = avx2SubInplaceInt32
+		simdMulInplaceInt32 = avx2MulInplaceInt32
+
+		simdAddVectorizedInt32 = avx2AddVectorizedInt32
+		simdSubVectorizedInt32 = avx2SubVectorizedInt32
+		simdMulVectorizedInt32 = avx2MulVectorizedInt32
+	}
+	if archsimd.X86.AVX512() {
+		simdAddInplaceInt32 = avx512AddInplaceInt32
+		simdSubInplaceInt32 = avx512SubInplaceInt32
+		simdMulInplaceInt32 = avx512MulInplaceInt32
+
+		simdAddVectorizedInt32 = avx512AddVectorizedInt32
+		simdSubVectorizedInt32 = avx512SubVectorizedInt32
+		simdMulVectorizedInt32 = avx512MulVectorizedInt32
+	}
+}
+
+func avx2AddInplaceInt32(a, b []int32) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt32x8Slice(b[i : i+8])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] += b[i]
+	}
+}
+
+func avx512AddInplaceInt32(a, b []int32) {
+	n := len(a)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadInt32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadInt32x16Slice(b[i : i+16])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(a[i : i+16])
+	}
+	for ; i < n; i++ {
+		a[i] += b[i]
+	}
+}
+
+func avx2SubInplaceInt32(a, b []int32) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt32x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] -= b[i]
+	}
+}
+
+func avx512SubInplaceInt32(a, b []int32) {
+	n := len(a)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadInt32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadInt32x16Slice(b[i : i+16])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(a[i : i+16])
+	}
+	for ; i < n; i++ {
+		a[i] -= b[i]
+	}
+}
+
+func avx2MulInplaceInt32(a, b []int32) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt32x8Slice(b[i : i+8])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] *= b[i]
+	}
+}
+
+func avx512MulInplaceInt32(a, b []int32) {
+	n := len(a)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadInt32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadInt32x16Slice(b[i : i+16])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(a[i : i+16])
+	}
+	for ; i < n; i++ {
+		a[i] *= b[i]
+	}
+}
+
+func avx2AddVectorizedInt32(dst, a, b []int32) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt32x8Slice(b[i : i+8])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] + b[i]
+	}
+}
+
+func avx512AddVectorizedInt32(dst, a, b []int32) {
+	n := len(dst)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadInt32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadInt32x16Slice(b[i : i+16])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(dst[i : i+16])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] + b[i]
+	}
+}
+
+func avx2SubVectorizedInt32(dst, a, b []int32) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt32x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] - b[i]
+	}
+}
+
+func avx512SubVectorizedInt32(dst, a, b []int32) {
+	n := len(dst)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadInt32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadInt32x16Slice(b[i : i+16])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+16])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] - b[i]
+	}
+}
+
+func avx2MulVectorizedInt32(dst, a, b []int32) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt32x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt32x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Mul(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] * b[i]
+	}
+}
+
+func avx512MulVectorizedInt32(dst, a, b []int32) {
+	n := len(dst)
+	i := 0
+	for ; i+16 <= n; i += 16 {
+		aLoaded := archsimd.LoadInt32x16Slice(a[i : i+16])
+		bLoaded := archsimd.LoadInt32x16Slice(b[i : i+16])
+		subLoaded := aLoaded.Mul(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+16])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] * b[i]
+	}
+}

--- a/internal/backend/cpu/ops_int32_simd_amd64.go
+++ b/internal/backend/cpu/ops_int32_simd_amd64.go
@@ -35,6 +35,8 @@ func init() {
 	}
 }
 
+// avx2AddInplaceInt32 computes a[i] += b[i] using AVX2 (256-bit, 8 int32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx2AddInplaceInt32(a, b []int32) {
 	n := len(a)
 	i := 0
@@ -49,6 +51,8 @@ func avx2AddInplaceInt32(a, b []int32) {
 	}
 }
 
+// avx512AddInplaceInt32 computes a[i] += b[i] using AVX-512 (512-bit, 16 int32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512AddInplaceInt32(a, b []int32) {
 	n := len(a)
 	i := 0
@@ -63,6 +67,8 @@ func avx512AddInplaceInt32(a, b []int32) {
 	}
 }
 
+// avx2SubInplaceInt32 computes a[i] -= b[i] using AVX2 (256-bit, 8 int32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx2SubInplaceInt32(a, b []int32) {
 	n := len(a)
 	i := 0
@@ -77,6 +83,8 @@ func avx2SubInplaceInt32(a, b []int32) {
 	}
 }
 
+// avx512SubInplaceInt32 computes a[i] -= b[i] using AVX-512 (512-bit, 16 int32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512SubInplaceInt32(a, b []int32) {
 	n := len(a)
 	i := 0
@@ -91,6 +99,8 @@ func avx512SubInplaceInt32(a, b []int32) {
 	}
 }
 
+// avx2MulInplaceInt32 computes a[i] *= b[i] using AVX2 (256-bit, 8 int32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx2MulInplaceInt32(a, b []int32) {
 	n := len(a)
 	i := 0
@@ -105,6 +115,8 @@ func avx2MulInplaceInt32(a, b []int32) {
 	}
 }
 
+// avx512MulInplaceInt32 computes a[i] *= b[i] using AVX-512 (512-bit, 16 int32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512MulInplaceInt32(a, b []int32) {
 	n := len(a)
 	i := 0
@@ -119,6 +131,8 @@ func avx512MulInplaceInt32(a, b []int32) {
 	}
 }
 
+// avx2AddVectorizedInt32 computes dst[i] = a[i] + b[i] using AVX2 (256-bit, 8 int32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx2AddVectorizedInt32(dst, a, b []int32) {
 	n := len(dst)
 	i := 0
@@ -133,6 +147,8 @@ func avx2AddVectorizedInt32(dst, a, b []int32) {
 	}
 }
 
+// avx512AddVectorizedInt32 computes dst[i] = a[i] + b[i] using AVX-512 (512-bit, 16 int32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512AddVectorizedInt32(dst, a, b []int32) {
 	n := len(dst)
 	i := 0
@@ -147,6 +163,8 @@ func avx512AddVectorizedInt32(dst, a, b []int32) {
 	}
 }
 
+// avx2SubVectorizedInt32 computes dst[i] = a[i] - b[i] using AVX2 (256-bit, 8 int32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx2SubVectorizedInt32(dst, a, b []int32) {
 	n := len(dst)
 	i := 0
@@ -161,6 +179,8 @@ func avx2SubVectorizedInt32(dst, a, b []int32) {
 	}
 }
 
+// avx512SubVectorizedInt32 computes dst[i] = a[i] - b[i] using AVX-512 (512-bit, 16 int32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512SubVectorizedInt32(dst, a, b []int32) {
 	n := len(dst)
 	i := 0
@@ -175,6 +195,8 @@ func avx512SubVectorizedInt32(dst, a, b []int32) {
 	}
 }
 
+// avx2MulVectorizedInt32 computes dst[i] = a[i] * b[i] using AVX2 (256-bit, 8 int32/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx2MulVectorizedInt32(dst, a, b []int32) {
 	n := len(dst)
 	i := 0
@@ -189,6 +211,8 @@ func avx2MulVectorizedInt32(dst, a, b []int32) {
 	}
 }
 
+// avx512MulVectorizedInt32 computes dst[i] = a[i] * b[i] using AVX-512 (512-bit, 16 int32/vector).
+// Processes 16 elements per vector iteration with a scalar tail for the final 0-15 elements.
 func avx512MulVectorizedInt32(dst, a, b []int32) {
 	n := len(dst)
 	i := 0

--- a/internal/backend/cpu/ops_int32_simd_amd64.go
+++ b/internal/backend/cpu/ops_int32_simd_amd64.go
@@ -203,8 +203,8 @@ func avx2MulVectorizedInt32(dst, a, b []int32) {
 	for ; i+8 <= n; i += 8 {
 		aLoaded := archsimd.LoadInt32x8Slice(a[i : i+8])
 		bLoaded := archsimd.LoadInt32x8Slice(b[i : i+8])
-		subLoaded := aLoaded.Mul(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+8])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(dst[i : i+8])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] * b[i]
@@ -219,8 +219,8 @@ func avx512MulVectorizedInt32(dst, a, b []int32) {
 	for ; i+16 <= n; i += 16 {
 		aLoaded := archsimd.LoadInt32x16Slice(a[i : i+16])
 		bLoaded := archsimd.LoadInt32x16Slice(b[i : i+16])
-		subLoaded := aLoaded.Mul(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+16])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(dst[i : i+16])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] * b[i]

--- a/internal/backend/cpu/ops_int32_simd_stub.go
+++ b/internal/backend/cpu/ops_int32_simd_stub.go
@@ -1,0 +1,14 @@
+//go:build !amd64 || !goexperiment.simd
+
+package cpu
+
+// These functions are nil when SIMD is unavailable (non-amd64 or built
+// without GOEXPERIMENT=simd).  They fall back to the scalar
+// loop when nil.
+var simdAddInplaceInt32 func(a, b []int32)
+var simdSubInplaceInt32 func(a, b []int32)
+var simdMulInplaceInt32 func(a, b []int32)
+
+var simdAddVectorizedInt32 func(dst, a, b []int32)
+var simdSubVectorizedInt32 func(dst, a, b []int32)
+var simdMulVectorizedInt32 func(dst, a, b []int32)

--- a/internal/backend/cpu/ops_int32_simd_stub.go
+++ b/internal/backend/cpu/ops_int32_simd_stub.go
@@ -5,6 +5,9 @@ package cpu
 // These functions are nil when SIMD is unavailable (non-amd64 or built
 // without GOEXPERIMENT=simd).  They fall back to the scalar
 // loop when nil.
+//
+// Note: SIMD integer division is not supported by simd/archsimd,
+// the scalar fallback is used for all division operations.
 var simdAddInplaceInt32 func(a, b []int32)
 var simdSubInplaceInt32 func(a, b []int32)
 var simdMulInplaceInt32 func(a, b []int32)

--- a/internal/backend/cpu/ops_int32_simd_test.go
+++ b/internal/backend/cpu/ops_int32_simd_test.go
@@ -37,7 +37,7 @@ func BenchmarkAddInplaceI32_Scalar(b *testing.B) {
 // BenchmarkAddInplaceI32_SIMD benchmarks a[i] += b[i] using the SIMD implementation.
 func BenchmarkAddInplaceI32_SIMD(b *testing.B) {
 	if simdAddInplaceInt32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()
@@ -64,7 +64,7 @@ func BenchmarkSubInplaceI32_Scalar(b *testing.B) {
 // BenchmarkSubInplaceI32_SIMD benchmarks a[i] -= b[i] using the SIMD implementation.
 func BenchmarkSubInplaceI32_SIMD(b *testing.B) {
 	if simdSubInplaceInt32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()
@@ -91,7 +91,7 @@ func BenchmarkMulInplaceI32_Scalar(b *testing.B) {
 // BenchmarkMulInplaceI32_SIMD benchmarks a[i] *= b[i] using the SIMD implementation.
 func BenchmarkMulInplaceI32_SIMD(b *testing.B) {
 	if simdMulInplaceInt32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()
@@ -119,7 +119,7 @@ func BenchmarkAddVectorizedI32_Scalar(b *testing.B) {
 // BenchmarkAddVectorizedI32_SIMD benchmarks dst[i] = a[i] + b[i] using the SIMD implementation.
 func BenchmarkAddVectorizedI32_SIMD(b *testing.B) {
 	if simdAddVectorizedInt32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()
@@ -148,7 +148,7 @@ func BenchmarkSubVectorizedI32_Scalar(b *testing.B) {
 // BenchmarkSubVectorizedI32_SIMD benchmarks dst[i] = a[i] - b[i] using the SIMD implementation.
 func BenchmarkSubVectorizedI32_SIMD(b *testing.B) {
 	if simdSubVectorizedInt32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()
@@ -177,7 +177,7 @@ func BenchmarkMulVectorizedI32_Scalar(b *testing.B) {
 // BenchmarkMulVectorizedI32_SIMD benchmarks dst[i] = a[i] * b[i] using the SIMD implementation.
 func BenchmarkMulVectorizedI32_SIMD(b *testing.B) {
 	if simdMulVectorizedInt32 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()

--- a/internal/backend/cpu/ops_int32_simd_test.go
+++ b/internal/backend/cpu/ops_int32_simd_test.go
@@ -1,0 +1,176 @@
+package cpu
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func createRandomInt32Slices() ([]int32, []int32) {
+	aSlice := make([]int32, 1024)
+	bSlice := make([]int32, 1024)
+
+	rng := rand.New(rand.NewSource(0))
+	for i := range aSlice {
+		aSlice[i] = int32(rng.Int())
+	}
+	for i := range bSlice {
+		bSlice[i] = int32(rng.Int())
+	}
+	return aSlice, bSlice
+}
+
+func BenchmarkAddInplaceI32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt32Slices()
+
+	saved := simdAddInplaceInt32
+	simdAddInplaceInt32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		addInplaceInt32(aSlice, bSlice)
+	}
+	simdAddInplaceInt32 = saved
+}
+
+func BenchmarkAddInplaceI32_SIMD(b *testing.B) {
+	if simdAddInplaceInt32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt32Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		addInplaceInt32(aSlice, bSlice)
+	}
+}
+
+func BenchmarkSubInplaceI32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt32Slices()
+
+	saved := simdSubInplaceInt32
+	simdSubInplaceInt32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		subInplaceInt32(aSlice, bSlice)
+	}
+	simdSubInplaceInt32 = saved
+}
+
+func BenchmarkSubInplaceI32_SIMD(b *testing.B) {
+	if simdSubInplaceInt32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt32Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		subInplaceInt32(aSlice, bSlice)
+	}
+}
+
+func BenchmarkMulInplaceI32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt32Slices()
+
+	saved := simdMulInplaceInt32
+	simdMulInplaceInt32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		mulInplaceInt32(aSlice, bSlice)
+	}
+	simdMulInplaceInt32 = saved
+}
+
+func BenchmarkMulInplaceI32_SIMD(b *testing.B) {
+	if simdMulInplaceInt32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt32Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		mulInplaceInt32(aSlice, bSlice)
+	}
+}
+
+func BenchmarkAddVectorizedI32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt32Slices()
+	dst := make([]int32, len(aSlice))
+
+	saved := simdAddVectorizedInt32
+	simdAddVectorizedInt32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		addVectorizedInt32(dst, aSlice, bSlice)
+	}
+	simdAddVectorizedInt32 = saved
+}
+
+func BenchmarkAddVectorizedI32_SIMD(b *testing.B) {
+	if simdAddVectorizedInt32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt32Slices()
+	dst := make([]int32, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		addVectorizedInt32(dst, aSlice, bSlice)
+	}
+}
+
+func BenchmarkSubVectorizedI32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt32Slices()
+	dst := make([]int32, len(aSlice))
+
+	saved := simdSubVectorizedInt32
+	simdSubVectorizedInt32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		subVectorizedInt32(dst, aSlice, bSlice)
+	}
+	simdSubVectorizedInt32 = saved
+}
+
+func BenchmarkSubVectorizedI32_SIMD(b *testing.B) {
+	if simdSubVectorizedInt32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt32Slices()
+	dst := make([]int32, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		subVectorizedInt32(dst, aSlice, bSlice)
+	}
+}
+
+func BenchmarkMulVectorizedI32_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt32Slices()
+	dst := make([]int32, len(aSlice))
+
+	saved := simdMulVectorizedInt32
+	simdMulVectorizedInt32 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		mulVectorizedInt32(dst, aSlice, bSlice)
+	}
+	simdMulVectorizedInt32 = saved
+}
+
+func BenchmarkMulVectorizedI32_SIMD(b *testing.B) {
+	if simdMulVectorizedInt32 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt32Slices()
+	dst := make([]int32, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		mulVectorizedInt32(dst, aSlice, bSlice)
+	}
+}

--- a/internal/backend/cpu/ops_int32_simd_test.go
+++ b/internal/backend/cpu/ops_int32_simd_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+// createRandomInt32Slices returns two 1024-element slices filled with
+// random int32 values, suitable for benchmarking element-wise ops.
 func createRandomInt32Slices() ([]int32, []int32) {
 	aSlice := make([]int32, 1024)
 	bSlice := make([]int32, 1024)
@@ -19,6 +21,7 @@ func createRandomInt32Slices() ([]int32, []int32) {
 	return aSlice, bSlice
 }
 
+// BenchmarkAddInplaceI32_Scalar benchmarks a[i] += b[i] using the scalar fallback.
 func BenchmarkAddInplaceI32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt32Slices()
 
@@ -31,9 +34,10 @@ func BenchmarkAddInplaceI32_Scalar(b *testing.B) {
 	simdAddInplaceInt32 = saved
 }
 
+// BenchmarkAddInplaceI32_SIMD benchmarks a[i] += b[i] using the SIMD implementation.
 func BenchmarkAddInplaceI32_SIMD(b *testing.B) {
 	if simdAddInplaceInt32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()
@@ -44,6 +48,7 @@ func BenchmarkAddInplaceI32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkSubInplaceI32_Scalar benchmarks a[i] -= b[i] using the scalar fallback.
 func BenchmarkSubInplaceI32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt32Slices()
 
@@ -56,9 +61,10 @@ func BenchmarkSubInplaceI32_Scalar(b *testing.B) {
 	simdSubInplaceInt32 = saved
 }
 
+// BenchmarkSubInplaceI32_SIMD benchmarks a[i] -= b[i] using the SIMD implementation.
 func BenchmarkSubInplaceI32_SIMD(b *testing.B) {
 	if simdSubInplaceInt32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()
@@ -69,6 +75,7 @@ func BenchmarkSubInplaceI32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkMulInplaceI32_Scalar benchmarks a[i] *= b[i] using the scalar fallback.
 func BenchmarkMulInplaceI32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt32Slices()
 
@@ -81,9 +88,10 @@ func BenchmarkMulInplaceI32_Scalar(b *testing.B) {
 	simdMulInplaceInt32 = saved
 }
 
+// BenchmarkMulInplaceI32_SIMD benchmarks a[i] *= b[i] using the SIMD implementation.
 func BenchmarkMulInplaceI32_SIMD(b *testing.B) {
 	if simdMulInplaceInt32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()
@@ -94,6 +102,7 @@ func BenchmarkMulInplaceI32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkAddVectorizedI32_Scalar benchmarks dst[i] = a[i] + b[i] using the scalar fallback.
 func BenchmarkAddVectorizedI32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt32Slices()
 	dst := make([]int32, len(aSlice))
@@ -107,9 +116,10 @@ func BenchmarkAddVectorizedI32_Scalar(b *testing.B) {
 	simdAddVectorizedInt32 = saved
 }
 
+// BenchmarkAddVectorizedI32_SIMD benchmarks dst[i] = a[i] + b[i] using the SIMD implementation.
 func BenchmarkAddVectorizedI32_SIMD(b *testing.B) {
 	if simdAddVectorizedInt32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()
@@ -121,6 +131,7 @@ func BenchmarkAddVectorizedI32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkSubVectorizedI32_Scalar benchmarks dst[i] = a[i] - b[i] using the scalar fallback.
 func BenchmarkSubVectorizedI32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt32Slices()
 	dst := make([]int32, len(aSlice))
@@ -134,9 +145,10 @@ func BenchmarkSubVectorizedI32_Scalar(b *testing.B) {
 	simdSubVectorizedInt32 = saved
 }
 
+// BenchmarkSubVectorizedI32_SIMD benchmarks dst[i] = a[i] - b[i] using the SIMD implementation.
 func BenchmarkSubVectorizedI32_SIMD(b *testing.B) {
 	if simdSubVectorizedInt32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()
@@ -148,6 +160,7 @@ func BenchmarkSubVectorizedI32_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkMulVectorizedI32_Scalar benchmarks dst[i] = a[i] * b[i] using the scalar fallback.
 func BenchmarkMulVectorizedI32_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt32Slices()
 	dst := make([]int32, len(aSlice))
@@ -161,9 +174,10 @@ func BenchmarkMulVectorizedI32_Scalar(b *testing.B) {
 	simdMulVectorizedInt32 = saved
 }
 
+// BenchmarkMulVectorizedI32_SIMD benchmarks dst[i] = a[i] * b[i] using the SIMD implementation.
 func BenchmarkMulVectorizedI32_SIMD(b *testing.B) {
 	if simdMulVectorizedInt32 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt32Slices()

--- a/internal/backend/cpu/ops_int64_simd_amd64.go
+++ b/internal/backend/cpu/ops_int64_simd_amd64.go
@@ -33,6 +33,8 @@ func init() {
 	}
 }
 
+// avx2AddInplaceInt64 computes a[i] += b[i] using AVX2 (256-bit, 4 int64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avx2AddInplaceInt64(a, b []int64) {
 	n := len(a)
 	i := 0
@@ -47,6 +49,8 @@ func avx2AddInplaceInt64(a, b []int64) {
 	}
 }
 
+// avx512AddInplaceInt64 computes a[i] += b[i] using AVX-512 (512-bit, 8 int64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512AddInplaceInt64(a, b []int64) {
 	n := len(a)
 	i := 0
@@ -61,6 +65,8 @@ func avx512AddInplaceInt64(a, b []int64) {
 	}
 }
 
+// avx2SubInplaceInt64 computes a[i] -= b[i] using AVX2 (256-bit, 4 int64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avx2SubInplaceInt64(a, b []int64) {
 	n := len(a)
 	i := 0
@@ -75,6 +81,8 @@ func avx2SubInplaceInt64(a, b []int64) {
 	}
 }
 
+// avx512SubInplaceInt64 computes a[i] -= b[i] using AVX-512 (512-bit, 8 int64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512SubInplaceInt64(a, b []int64) {
 	n := len(a)
 	i := 0
@@ -89,6 +97,8 @@ func avx512SubInplaceInt64(a, b []int64) {
 	}
 }
 
+// avx512MulInplaceInt64 computes a[i] *= b[i] using AVX-512 (512-bit, 8 int64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512MulInplaceInt64(a, b []int64) {
 	n := len(a)
 	i := 0
@@ -103,6 +113,8 @@ func avx512MulInplaceInt64(a, b []int64) {
 	}
 }
 
+// avx2AddVectorizedInt64 computes dst[i] = a[i] + b[i] using AVX2 (256-bit, 4 int64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avx2AddVectorizedInt64(dst, a, b []int64) {
 	n := len(dst)
 	i := 0
@@ -117,6 +129,8 @@ func avx2AddVectorizedInt64(dst, a, b []int64) {
 	}
 }
 
+// avx512AddVectorizedInt64 computes dst[i] = a[i] + b[i] using AVX-512 (512-bit, 8 int64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512AddVectorizedInt64(dst, a, b []int64) {
 	n := len(dst)
 	i := 0
@@ -131,6 +145,8 @@ func avx512AddVectorizedInt64(dst, a, b []int64) {
 	}
 }
 
+// avx2SubVectorizedInt64 computes dst[i] = a[i] - b[i] using AVX2 (256-bit, 4 int64/vector).
+// Processes 4 elements per vector iteration with a scalar tail for the final 0-3 elements.
 func avx2SubVectorizedInt64(dst, a, b []int64) {
 	n := len(dst)
 	i := 0
@@ -145,6 +161,8 @@ func avx2SubVectorizedInt64(dst, a, b []int64) {
 	}
 }
 
+// avx512SubVectorizedInt64 computes dst[i] = a[i] - b[i] using AVX-512 (512-bit, 8 int64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512SubVectorizedInt64(dst, a, b []int64) {
 	n := len(dst)
 	i := 0
@@ -159,6 +177,8 @@ func avx512SubVectorizedInt64(dst, a, b []int64) {
 	}
 }
 
+// avx512MulVectorizedInt64 computes dst[i] = a[i] * b[i] using AVX-512 (512-bit, 8 int64/vector).
+// Processes 8 elements per vector iteration with a scalar tail for the final 0-7 elements.
 func avx512MulVectorizedInt64(dst, a, b []int64) {
 	n := len(dst)
 	i := 0

--- a/internal/backend/cpu/ops_int64_simd_amd64.go
+++ b/internal/backend/cpu/ops_int64_simd_amd64.go
@@ -1,0 +1,174 @@
+//go:build amd64 && goexperiment.simd
+
+package cpu
+
+import "simd/archsimd"
+
+// Declared here for amd64+goexperiment.simd builds; the stub file provides the
+// same declaration for all other platforms/configurations.
+var simdAddInplaceInt64 func(a, b []int64)
+var simdSubInplaceInt64 func(a, b []int64)
+var simdMulInplaceInt64 func(a, b []int64)
+
+var simdAddVectorizedInt64 func(dst, a, b []int64)
+var simdSubVectorizedInt64 func(dst, a, b []int64)
+var simdMulVectorizedInt64 func(dst, a, b []int64)
+
+func init() {
+	if archsimd.X86.AVX2() {
+		simdAddInplaceInt64 = avx2AddInplaceInt64
+		simdSubInplaceInt64 = avx2SubInplaceInt64
+
+		simdAddVectorizedInt64 = avx2AddVectorizedInt64
+		simdSubVectorizedInt64 = avx2SubVectorizedInt64
+	}
+	if archsimd.X86.AVX512() {
+		simdAddInplaceInt64 = avx512AddInplaceInt64
+		simdSubInplaceInt64 = avx512SubInplaceInt64
+		simdMulInplaceInt64 = avx512MulInplaceInt64
+
+		simdAddVectorizedInt64 = avx512AddVectorizedInt64
+		simdSubVectorizedInt64 = avx512SubVectorizedInt64
+		simdMulVectorizedInt64 = avx512MulVectorizedInt64
+	}
+}
+
+func avx2AddInplaceInt64(a, b []int64) {
+	n := len(a)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadInt64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadInt64x4Slice(b[i : i+4])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(a[i : i+4])
+	}
+	for ; i < n; i++ {
+		a[i] += b[i]
+	}
+}
+
+func avx512AddInplaceInt64(a, b []int64) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt64x8Slice(b[i : i+8])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] += b[i]
+	}
+}
+
+func avx2SubInplaceInt64(a, b []int64) {
+	n := len(a)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadInt64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadInt64x4Slice(b[i : i+4])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(a[i : i+4])
+	}
+	for ; i < n; i++ {
+		a[i] -= b[i]
+	}
+}
+
+func avx512SubInplaceInt64(a, b []int64) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt64x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] -= b[i]
+	}
+}
+
+func avx512MulInplaceInt64(a, b []int64) {
+	n := len(a)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt64x8Slice(b[i : i+8])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(a[i : i+8])
+	}
+	for ; i < n; i++ {
+		a[i] *= b[i]
+	}
+}
+
+func avx2AddVectorizedInt64(dst, a, b []int64) {
+	n := len(dst)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadInt64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadInt64x4Slice(b[i : i+4])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(dst[i : i+4])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] + b[i]
+	}
+}
+
+func avx512AddVectorizedInt64(dst, a, b []int64) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt64x8Slice(b[i : i+8])
+		sumLoaded := aLoaded.Add(bLoaded)
+		sumLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] + b[i]
+	}
+}
+
+func avx2SubVectorizedInt64(dst, a, b []int64) {
+	n := len(dst)
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		aLoaded := archsimd.LoadInt64x4Slice(a[i : i+4])
+		bLoaded := archsimd.LoadInt64x4Slice(b[i : i+4])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+4])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] - b[i]
+	}
+}
+
+func avx512SubVectorizedInt64(dst, a, b []int64) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt64x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Sub(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] - b[i]
+	}
+}
+
+func avx512MulVectorizedInt64(dst, a, b []int64) {
+	n := len(dst)
+	i := 0
+	for ; i+8 <= n; i += 8 {
+		aLoaded := archsimd.LoadInt64x8Slice(a[i : i+8])
+		bLoaded := archsimd.LoadInt64x8Slice(b[i : i+8])
+		subLoaded := aLoaded.Mul(bLoaded)
+		subLoaded.StoreSlice(dst[i : i+8])
+	}
+	for ; i < n; i++ {
+		dst[i] = a[i] * b[i]
+	}
+}

--- a/internal/backend/cpu/ops_int64_simd_amd64.go
+++ b/internal/backend/cpu/ops_int64_simd_amd64.go
@@ -185,8 +185,8 @@ func avx512MulVectorizedInt64(dst, a, b []int64) {
 	for ; i+8 <= n; i += 8 {
 		aLoaded := archsimd.LoadInt64x8Slice(a[i : i+8])
 		bLoaded := archsimd.LoadInt64x8Slice(b[i : i+8])
-		subLoaded := aLoaded.Mul(bLoaded)
-		subLoaded.StoreSlice(dst[i : i+8])
+		mulLoaded := aLoaded.Mul(bLoaded)
+		mulLoaded.StoreSlice(dst[i : i+8])
 	}
 	for ; i < n; i++ {
 		dst[i] = a[i] * b[i]

--- a/internal/backend/cpu/ops_int64_simd_stub.go
+++ b/internal/backend/cpu/ops_int64_simd_stub.go
@@ -1,0 +1,14 @@
+//go:build !amd64 || !goexperiment.simd
+
+package cpu
+
+// These functions are nil when SIMD is unavailable (non-amd64 or built
+// without GOEXPERIMENT=simd).  They fall back to the scalar
+// loop when nil.
+var simdAddInplaceInt64 func(a, b []int64)
+var simdSubInplaceInt64 func(a, b []int64)
+var simdMulInplaceInt64 func(a, b []int64)
+
+var simdAddVectorizedInt64 func(dst, a, b []int64)
+var simdSubVectorizedInt64 func(dst, a, b []int64)
+var simdMulVectorizedInt64 func(dst, a, b []int64)

--- a/internal/backend/cpu/ops_int64_simd_stub.go
+++ b/internal/backend/cpu/ops_int64_simd_stub.go
@@ -5,6 +5,9 @@ package cpu
 // These functions are nil when SIMD is unavailable (non-amd64 or built
 // without GOEXPERIMENT=simd).  They fall back to the scalar
 // loop when nil.
+//
+// Note: SIMD integer division is not supported by simd/archsimd,
+// the scalar fallback is used for all division operations.
 var simdAddInplaceInt64 func(a, b []int64)
 var simdSubInplaceInt64 func(a, b []int64)
 var simdMulInplaceInt64 func(a, b []int64)

--- a/internal/backend/cpu/ops_int64_simd_test.go
+++ b/internal/backend/cpu/ops_int64_simd_test.go
@@ -19,6 +19,7 @@ func createRandomInt64Slices() ([]int64, []int64) {
 	return aSlice, bSlice
 }
 
+// BenchmarkAddInplaceI64_Scalar benchmarks a[i] += b[i] using the scalar fallback.
 func BenchmarkAddInplaceI64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt64Slices()
 
@@ -31,9 +32,10 @@ func BenchmarkAddInplaceI64_Scalar(b *testing.B) {
 	simdAddInplaceInt64 = saved
 }
 
+// BenchmarkAddInplaceI64_SIMD benchmarks a[i] += b[i] using the SIMD implementation.
 func BenchmarkAddInplaceI64_SIMD(b *testing.B) {
 	if simdAddInplaceInt64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()
@@ -44,6 +46,7 @@ func BenchmarkAddInplaceI64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkSubInplaceI64_Scalar benchmarks a[i] -= b[i] using the scalar fallback.
 func BenchmarkSubInplaceI64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt64Slices()
 
@@ -56,9 +59,10 @@ func BenchmarkSubInplaceI64_Scalar(b *testing.B) {
 	simdSubInplaceInt64 = saved
 }
 
+// BenchmarkSubInplaceI64_SIMD benchmarks a[i] -= b[i] using the SIMD implementation.
 func BenchmarkSubInplaceI64_SIMD(b *testing.B) {
 	if simdSubInplaceInt64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()
@@ -69,6 +73,7 @@ func BenchmarkSubInplaceI64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkMulInplaceI64_Scalar benchmarks a[i] *= b[i] using the scalar fallback.
 func BenchmarkMulInplaceI64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt64Slices()
 
@@ -81,9 +86,10 @@ func BenchmarkMulInplaceI64_Scalar(b *testing.B) {
 	simdMulInplaceInt64 = saved
 }
 
+// BenchmarkMulInplaceI64_SIMD benchmarks a[i] *= b[i] using the SIMD implementation.
 func BenchmarkMulInplaceI64_SIMD(b *testing.B) {
 	if simdMulInplaceInt64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()
@@ -94,6 +100,7 @@ func BenchmarkMulInplaceI64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkAddVectorizedI64_Scalar benchmarks dst[i] = a[i] + b[i] using the scalar fallback.
 func BenchmarkAddVectorizedI64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt64Slices()
 	dst := make([]int64, len(aSlice))
@@ -107,9 +114,10 @@ func BenchmarkAddVectorizedI64_Scalar(b *testing.B) {
 	simdAddVectorizedInt64 = saved
 }
 
+// BenchmarkAddVectorizedI64_SIMD benchmarks dst[i] = a[i] + b[i] using the SIMD implementation.
 func BenchmarkAddVectorizedI64_SIMD(b *testing.B) {
 	if simdAddVectorizedInt64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()
@@ -121,6 +129,7 @@ func BenchmarkAddVectorizedI64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkSubVectorizedI64_Scalar benchmarks dst[i] = a[i] - b[i] using the scalar fallback.
 func BenchmarkSubVectorizedI64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt64Slices()
 	dst := make([]int64, len(aSlice))
@@ -134,9 +143,10 @@ func BenchmarkSubVectorizedI64_Scalar(b *testing.B) {
 	simdSubVectorizedInt64 = saved
 }
 
+// BenchmarkSubVectorizedI64_SIMD benchmarks dst[i] = a[i] - b[i] using the SIMD implementation.
 func BenchmarkSubVectorizedI64_SIMD(b *testing.B) {
 	if simdSubVectorizedInt64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()
@@ -148,6 +158,7 @@ func BenchmarkSubVectorizedI64_SIMD(b *testing.B) {
 	}
 }
 
+// BenchmarkMulVectorizedI64_Scalar benchmarks dst[i] = a[i] * b[i] using the scalar fallback.
 func BenchmarkMulVectorizedI64_Scalar(b *testing.B) {
 	aSlice, bSlice := createRandomInt64Slices()
 	dst := make([]int64, len(aSlice))
@@ -161,9 +172,10 @@ func BenchmarkMulVectorizedI64_Scalar(b *testing.B) {
 	simdMulVectorizedInt64 = saved
 }
 
+// BenchmarkMulVectorizedI64_SIMD benchmarks dst[i] = a[i] * b[i] using the SIMD implementation.
 func BenchmarkMulVectorizedI64_SIMD(b *testing.B) {
 	if simdMulVectorizedInt64 == nil {
-		b.Skip("SIMD kernel not available")
+		b.Skip("SIMD implementation not available")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()

--- a/internal/backend/cpu/ops_int64_simd_test.go
+++ b/internal/backend/cpu/ops_int64_simd_test.go
@@ -35,7 +35,7 @@ func BenchmarkAddInplaceI64_Scalar(b *testing.B) {
 // BenchmarkAddInplaceI64_SIMD benchmarks a[i] += b[i] using the SIMD implementation.
 func BenchmarkAddInplaceI64_SIMD(b *testing.B) {
 	if simdAddInplaceInt64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()
@@ -62,7 +62,7 @@ func BenchmarkSubInplaceI64_Scalar(b *testing.B) {
 // BenchmarkSubInplaceI64_SIMD benchmarks a[i] -= b[i] using the SIMD implementation.
 func BenchmarkSubInplaceI64_SIMD(b *testing.B) {
 	if simdSubInplaceInt64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()
@@ -89,7 +89,7 @@ func BenchmarkMulInplaceI64_Scalar(b *testing.B) {
 // BenchmarkMulInplaceI64_SIMD benchmarks a[i] *= b[i] using the SIMD implementation.
 func BenchmarkMulInplaceI64_SIMD(b *testing.B) {
 	if simdMulInplaceInt64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()
@@ -117,7 +117,7 @@ func BenchmarkAddVectorizedI64_Scalar(b *testing.B) {
 // BenchmarkAddVectorizedI64_SIMD benchmarks dst[i] = a[i] + b[i] using the SIMD implementation.
 func BenchmarkAddVectorizedI64_SIMD(b *testing.B) {
 	if simdAddVectorizedInt64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()
@@ -146,7 +146,7 @@ func BenchmarkSubVectorizedI64_Scalar(b *testing.B) {
 // BenchmarkSubVectorizedI64_SIMD benchmarks dst[i] = a[i] - b[i] using the SIMD implementation.
 func BenchmarkSubVectorizedI64_SIMD(b *testing.B) {
 	if simdSubVectorizedInt64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()
@@ -175,7 +175,7 @@ func BenchmarkMulVectorizedI64_Scalar(b *testing.B) {
 // BenchmarkMulVectorizedI64_SIMD benchmarks dst[i] = a[i] * b[i] using the SIMD implementation.
 func BenchmarkMulVectorizedI64_SIMD(b *testing.B) {
 	if simdMulVectorizedInt64 == nil {
-		b.Skip("SIMD implementation not available")
+		b.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	aSlice, bSlice := createRandomInt64Slices()

--- a/internal/backend/cpu/ops_int64_simd_test.go
+++ b/internal/backend/cpu/ops_int64_simd_test.go
@@ -1,0 +1,176 @@
+package cpu
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func createRandomInt64Slices() ([]int64, []int64) {
+	aSlice := make([]int64, 1024)
+	bSlice := make([]int64, 1024)
+
+	rng := rand.New(rand.NewSource(0))
+	for i := range aSlice {
+		aSlice[i] = int64(rng.Int())
+	}
+	for i := range bSlice {
+		bSlice[i] = int64(rng.Int())
+	}
+	return aSlice, bSlice
+}
+
+func BenchmarkAddInplaceI64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt64Slices()
+
+	saved := simdAddInplaceInt64
+	simdAddInplaceInt64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		addInplaceInt64(aSlice, bSlice)
+	}
+	simdAddInplaceInt64 = saved
+}
+
+func BenchmarkAddInplaceI64_SIMD(b *testing.B) {
+	if simdAddInplaceInt64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt64Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		addInplaceInt64(aSlice, bSlice)
+	}
+}
+
+func BenchmarkSubInplaceI64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt64Slices()
+
+	saved := simdSubInplaceInt64
+	simdSubInplaceInt64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		subInplaceInt64(aSlice, bSlice)
+	}
+	simdSubInplaceInt64 = saved
+}
+
+func BenchmarkSubInplaceI64_SIMD(b *testing.B) {
+	if simdSubInplaceInt64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt64Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		subInplaceInt64(aSlice, bSlice)
+	}
+}
+
+func BenchmarkMulInplaceI64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt64Slices()
+
+	saved := simdMulInplaceInt64
+	simdMulInplaceInt64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		mulInplaceInt64(aSlice, bSlice)
+	}
+	simdMulInplaceInt64 = saved
+}
+
+func BenchmarkMulInplaceI64_SIMD(b *testing.B) {
+	if simdMulInplaceInt64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt64Slices()
+
+	b.ResetTimer()
+	for b.Loop() {
+		mulInplaceInt64(aSlice, bSlice)
+	}
+}
+
+func BenchmarkAddVectorizedI64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt64Slices()
+	dst := make([]int64, len(aSlice))
+
+	saved := simdAddVectorizedInt64
+	simdAddVectorizedInt64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		addVectorizedInt64(dst, aSlice, bSlice)
+	}
+	simdAddVectorizedInt64 = saved
+}
+
+func BenchmarkAddVectorizedI64_SIMD(b *testing.B) {
+	if simdAddVectorizedInt64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt64Slices()
+	dst := make([]int64, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		addVectorizedInt64(dst, aSlice, bSlice)
+	}
+}
+
+func BenchmarkSubVectorizedI64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt64Slices()
+	dst := make([]int64, len(aSlice))
+
+	saved := simdSubVectorizedInt64
+	simdSubVectorizedInt64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		subVectorizedInt64(dst, aSlice, bSlice)
+	}
+	simdSubVectorizedInt64 = saved
+}
+
+func BenchmarkSubVectorizedI64_SIMD(b *testing.B) {
+	if simdSubVectorizedInt64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt64Slices()
+	dst := make([]int64, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		subVectorizedInt64(dst, aSlice, bSlice)
+	}
+}
+
+func BenchmarkMulVectorizedI64_Scalar(b *testing.B) {
+	aSlice, bSlice := createRandomInt64Slices()
+	dst := make([]int64, len(aSlice))
+
+	saved := simdMulVectorizedInt64
+	simdMulVectorizedInt64 = nil
+	b.ResetTimer()
+	for b.Loop() {
+		mulVectorizedInt64(dst, aSlice, bSlice)
+	}
+	simdMulVectorizedInt64 = saved
+}
+
+func BenchmarkMulVectorizedI64_SIMD(b *testing.B) {
+	if simdMulVectorizedInt64 == nil {
+		b.Skip("SIMD kernel not available")
+	}
+
+	aSlice, bSlice := createRandomInt64Slices()
+	dst := make([]int64, len(aSlice))
+
+	b.ResetTimer()
+	for b.Loop() {
+		mulVectorizedInt64(dst, aSlice, bSlice)
+	}
+}

--- a/internal/backend/cpu/ops_simd_test.go
+++ b/internal/backend/cpu/ops_simd_test.go
@@ -10,7 +10,7 @@ import (
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestAddInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdAddInplaceFloat32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-5
@@ -50,7 +50,7 @@ func TestAddInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestSubInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdSubInplaceFloat32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-5
@@ -90,7 +90,7 @@ func TestSubInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestMulInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdMulInplaceFloat32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-5
@@ -130,7 +130,7 @@ func TestMulInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestDivInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdDivInplaceFloat32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-5
@@ -170,7 +170,7 @@ func TestDivInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestAddVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdAddVectorizedFloat32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-5
@@ -210,7 +210,7 @@ func TestAddVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestSubVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdSubVectorizedFloat32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-5
@@ -250,7 +250,7 @@ func TestSubVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestMulVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdMulVectorizedFloat32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-5
@@ -290,7 +290,7 @@ func TestMulVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestDivVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdDivVectorizedFloat32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-5
@@ -330,7 +330,7 @@ func TestDivVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestAddInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdAddInplaceFloat64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-10
@@ -370,7 +370,7 @@ func TestAddInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestSubInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdSubInplaceFloat64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-10
@@ -410,7 +410,7 @@ func TestSubInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestMulInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdMulInplaceFloat64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-10
@@ -450,7 +450,7 @@ func TestMulInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestDivInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdDivInplaceFloat64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-10
@@ -490,7 +490,7 @@ func TestDivInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestAddVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdAddVectorizedFloat64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-10
@@ -530,7 +530,7 @@ func TestAddVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestSubVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdSubVectorizedFloat64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-10
@@ -570,7 +570,7 @@ func TestSubVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestMulVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdMulVectorizedFloat64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-10
@@ -610,7 +610,7 @@ func TestMulVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestDivVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdDivVectorizedFloat64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	const maxDiff = 1e-10
@@ -650,7 +650,7 @@ func TestDivVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestAddInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdAddInplaceInt32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -687,7 +687,7 @@ func TestAddInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestSubInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdSubInplaceInt32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -725,7 +725,7 @@ func TestSubInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 // Uses small values to avoid integer overflow.
 func TestMulInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdMulInplaceInt32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -762,7 +762,7 @@ func TestMulInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestAddVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdAddVectorizedInt32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -799,7 +799,7 @@ func TestAddVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestSubVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdSubVectorizedInt32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -837,7 +837,7 @@ func TestSubVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 // Uses small values to avoid integer overflow.
 func TestMulVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdMulVectorizedInt32 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -874,7 +874,7 @@ func TestMulVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestAddInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdAddInplaceInt64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -911,7 +911,7 @@ func TestAddInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestSubInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdSubInplaceInt64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -949,7 +949,7 @@ func TestSubInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 // Uses small values to avoid integer overflow.
 func TestMulInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdMulInplaceInt64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -986,7 +986,7 @@ func TestMulInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestAddVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdAddVectorizedInt64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -1023,7 +1023,7 @@ func TestAddVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestSubVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdSubVectorizedInt64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -1061,7 +1061,7 @@ func TestSubVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
 // Uses small values to avoid integer overflow.
 func TestMulVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdMulVectorizedInt64 == nil {
-		t.Skip("SIMD kernel not available")
+		t.Skip("SIMD implementation not available")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}

--- a/internal/backend/cpu/ops_simd_test.go
+++ b/internal/backend/cpu/ops_simd_test.go
@@ -10,7 +10,7 @@ import (
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestAddInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdAddInplaceFloat32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-5
@@ -50,7 +50,7 @@ func TestAddInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestSubInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdSubInplaceFloat32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-5
@@ -90,7 +90,7 @@ func TestSubInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestMulInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdMulInplaceFloat32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-5
@@ -130,7 +130,7 @@ func TestMulInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestDivInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdDivInplaceFloat32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-5
@@ -170,7 +170,7 @@ func TestDivInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestAddVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdAddVectorizedFloat32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-5
@@ -210,7 +210,7 @@ func TestAddVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestSubVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdSubVectorizedFloat32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-5
@@ -250,7 +250,7 @@ func TestSubVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestMulVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdMulVectorizedFloat32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-5
@@ -290,7 +290,7 @@ func TestMulVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float32 ULP noise.
 func TestDivVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 	if simdDivVectorizedFloat32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-5
@@ -330,7 +330,7 @@ func TestDivVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestAddInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdAddInplaceFloat64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-10
@@ -370,7 +370,7 @@ func TestAddInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestSubInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdSubInplaceFloat64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-10
@@ -410,7 +410,7 @@ func TestSubInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestMulInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdMulInplaceFloat64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-10
@@ -450,7 +450,7 @@ func TestMulInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestDivInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdDivInplaceFloat64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-10
@@ -490,7 +490,7 @@ func TestDivInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestAddVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdAddVectorizedFloat64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-10
@@ -530,7 +530,7 @@ func TestAddVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestSubVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdSubVectorizedFloat64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-10
@@ -570,7 +570,7 @@ func TestSubVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestMulVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdMulVectorizedFloat64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-10
@@ -610,7 +610,7 @@ func TestMulVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces results matching the scalar fallback within float64 ULP noise.
 func TestDivVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 	if simdDivVectorizedFloat64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	const maxDiff = 1e-10
@@ -650,7 +650,7 @@ func TestDivVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestAddInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdAddInplaceInt32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -687,7 +687,7 @@ func TestAddInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestSubInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdSubInplaceInt32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -725,7 +725,7 @@ func TestSubInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 // Uses small values to avoid integer overflow.
 func TestMulInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdMulInplaceInt32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -762,7 +762,7 @@ func TestMulInplaceInt32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestAddVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdAddVectorizedInt32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -799,7 +799,7 @@ func TestAddVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestSubVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdSubVectorizedInt32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -837,7 +837,7 @@ func TestSubVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 // Uses small values to avoid integer overflow.
 func TestMulVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 	if simdMulVectorizedInt32 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -874,7 +874,7 @@ func TestMulVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestAddInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdAddInplaceInt64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -911,7 +911,7 @@ func TestAddInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestSubInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdSubInplaceInt64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -949,7 +949,7 @@ func TestSubInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 // Uses small values to avoid integer overflow.
 func TestMulInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdMulInplaceInt64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -986,7 +986,7 @@ func TestMulInplaceInt64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestAddVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdAddVectorizedInt64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -1023,7 +1023,7 @@ func TestAddVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
 // kernel produces bit-exact results matching the scalar fallback.
 func TestSubVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdSubVectorizedInt64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
@@ -1061,7 +1061,7 @@ func TestSubVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
 // Uses small values to avoid integer overflow.
 func TestMulVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
 	if simdMulVectorizedInt64 == nil {
-		t.Skip("SIMD implementation not available")
+		t.Skip("SIMD implementation not available (build without GOEXPERIMENT=simd or non-amd64)")
 	}
 
 	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}

--- a/internal/backend/cpu/ops_simd_test.go
+++ b/internal/backend/cpu/ops_simd_test.go
@@ -1,0 +1,1118 @@
+package cpu
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// TestAddInplaceFloat32_SIMDMatchesScalar verifies that the SIMD add-inplace
+// kernel produces results matching the scalar fallback within float32 ULP noise.
+func TestAddInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
+	if simdAddInplaceFloat32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-5
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(1))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float32, n)
+			b := make([]float32, n)
+			for i := range a {
+				a[i] = rng.Float32()*2 - 1
+				b[i] = rng.Float32()*2 - 1
+			}
+
+			aScalar := make([]float32, n)
+			copy(aScalar, a)
+			saved := simdAddInplaceFloat32
+			simdAddInplaceFloat32 = nil
+			addInplaceFloat32(aScalar, b)
+			simdAddInplaceFloat32 = saved
+
+			addInplaceFloat32(a, b)
+
+			for i := range a {
+				diff := math.Abs(float64(a[i] - aScalar[i]))
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.8f scalar=%.8f diff=%.2e", i, a[i], aScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestSubInplaceFloat32_SIMDMatchesScalar verifies that the SIMD sub-inplace
+// kernel produces results matching the scalar fallback within float32 ULP noise.
+func TestSubInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
+	if simdSubInplaceFloat32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-5
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(2))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float32, n)
+			b := make([]float32, n)
+			for i := range a {
+				a[i] = rng.Float32()*2 - 1
+				b[i] = rng.Float32()*2 - 1
+			}
+
+			aScalar := make([]float32, n)
+			copy(aScalar, a)
+			saved := simdSubInplaceFloat32
+			simdSubInplaceFloat32 = nil
+			subInplaceFloat32(aScalar, b)
+			simdSubInplaceFloat32 = saved
+
+			subInplaceFloat32(a, b)
+
+			for i := range a {
+				diff := math.Abs(float64(a[i] - aScalar[i]))
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.8f scalar=%.8f diff=%.2e", i, a[i], aScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestMulInplaceFloat32_SIMDMatchesScalar verifies that the SIMD mul-inplace
+// kernel produces results matching the scalar fallback within float32 ULP noise.
+func TestMulInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
+	if simdMulInplaceFloat32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-5
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(3))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float32, n)
+			b := make([]float32, n)
+			for i := range a {
+				a[i] = rng.Float32()*2 - 1
+				b[i] = rng.Float32()*2 - 1
+			}
+
+			aScalar := make([]float32, n)
+			copy(aScalar, a)
+			saved := simdMulInplaceFloat32
+			simdMulInplaceFloat32 = nil
+			mulInplaceFloat32(aScalar, b)
+			simdMulInplaceFloat32 = saved
+
+			mulInplaceFloat32(a, b)
+
+			for i := range a {
+				diff := math.Abs(float64(a[i] - aScalar[i]))
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.8f scalar=%.8f diff=%.2e", i, a[i], aScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestDivInplaceFloat32_SIMDMatchesScalar verifies that the SIMD div-inplace
+// kernel produces results matching the scalar fallback within float32 ULP noise.
+func TestDivInplaceFloat32_SIMDMatchesScalar(t *testing.T) {
+	if simdDivInplaceFloat32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-5
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(4))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float32, n)
+			b := make([]float32, n)
+			for i := range a {
+				a[i] = rng.Float32()*2 - 1
+				b[i] = rng.Float32()*2 - 0.5
+			}
+
+			aScalar := make([]float32, n)
+			copy(aScalar, a)
+			saved := simdDivInplaceFloat32
+			simdDivInplaceFloat32 = nil
+			divInplaceFloat32(aScalar, b)
+			simdDivInplaceFloat32 = saved
+
+			divInplaceFloat32(a, b)
+
+			for i := range a {
+				diff := math.Abs(float64(a[i] - aScalar[i]))
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.8f scalar=%.8f diff=%.2e", i, a[i], aScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestAddVectorizedFloat32_SIMDMatchesScalar verifies that the SIMD add-vectorized
+// kernel produces results matching the scalar fallback within float32 ULP noise.
+func TestAddVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
+	if simdAddVectorizedFloat32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-5
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(5))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float32, n)
+			b := make([]float32, n)
+			for i := range a {
+				a[i] = rng.Float32()*2 - 1
+				b[i] = rng.Float32()*2 - 1
+			}
+
+			dstScalar := make([]float32, n)
+			saved := simdAddVectorizedFloat32
+			simdAddVectorizedFloat32 = nil
+			addVectorizedFloat32(dstScalar, a, b)
+			simdAddVectorizedFloat32 = saved
+
+			dstSIMD := make([]float32, n)
+			addVectorizedFloat32(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				diff := math.Abs(float64(dstSIMD[i] - dstScalar[i]))
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.8f scalar=%.8f diff=%.2e", i, dstSIMD[i], dstScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestSubVectorizedFloat32_SIMDMatchesScalar verifies that the SIMD sub-vectorized
+// kernel produces results matching the scalar fallback within float32 ULP noise.
+func TestSubVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
+	if simdSubVectorizedFloat32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-5
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(6))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float32, n)
+			b := make([]float32, n)
+			for i := range a {
+				a[i] = rng.Float32()*2 - 1
+				b[i] = rng.Float32()*2 - 1
+			}
+
+			dstScalar := make([]float32, n)
+			saved := simdSubVectorizedFloat32
+			simdSubVectorizedFloat32 = nil
+			subVectorizedFloat32(dstScalar, a, b)
+			simdSubVectorizedFloat32 = saved
+
+			dstSIMD := make([]float32, n)
+			subVectorizedFloat32(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				diff := math.Abs(float64(dstSIMD[i] - dstScalar[i]))
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.8f scalar=%.8f diff=%.2e", i, dstSIMD[i], dstScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestMulVectorizedFloat32_SIMDMatchesScalar verifies that the SIMD mul-vectorized
+// kernel produces results matching the scalar fallback within float32 ULP noise.
+func TestMulVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
+	if simdMulVectorizedFloat32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-5
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(7))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float32, n)
+			b := make([]float32, n)
+			for i := range a {
+				a[i] = rng.Float32()*2 - 1
+				b[i] = rng.Float32()*2 - 1
+			}
+
+			dstScalar := make([]float32, n)
+			saved := simdMulVectorizedFloat32
+			simdMulVectorizedFloat32 = nil
+			mulVectorizedFloat32(dstScalar, a, b)
+			simdMulVectorizedFloat32 = saved
+
+			dstSIMD := make([]float32, n)
+			mulVectorizedFloat32(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				diff := math.Abs(float64(dstSIMD[i] - dstScalar[i]))
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.8f scalar=%.8f diff=%.2e", i, dstSIMD[i], dstScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestDivVectorizedFloat32_SIMDMatchesScalar verifies that the SIMD div-vectorized
+// kernel produces results matching the scalar fallback within float32 ULP noise.
+func TestDivVectorizedFloat32_SIMDMatchesScalar(t *testing.T) {
+	if simdDivVectorizedFloat32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-5
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(8))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float32, n)
+			b := make([]float32, n)
+			for i := range a {
+				a[i] = rng.Float32()*2 - 1
+				b[i] = rng.Float32()*2 - 0.5
+			}
+
+			dstScalar := make([]float32, n)
+			saved := simdDivVectorizedFloat32
+			simdDivVectorizedFloat32 = nil
+			divVectorizedFloat32(dstScalar, a, b)
+			simdDivVectorizedFloat32 = saved
+
+			dstSIMD := make([]float32, n)
+			divVectorizedFloat32(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				diff := math.Abs(float64(dstSIMD[i] - dstScalar[i]))
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.8f scalar=%.8f diff=%.2e", i, dstSIMD[i], dstScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestAddInplaceFloat64_SIMDMatchesScalar verifies that the SIMD add-inplace
+// kernel produces results matching the scalar fallback within float64 ULP noise.
+func TestAddInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
+	if simdAddInplaceFloat64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-10
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(10))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float64, n)
+			b := make([]float64, n)
+			for i := range a {
+				a[i] = rng.Float64()*2 - 1
+				b[i] = rng.Float64()*2 - 1
+			}
+
+			aScalar := make([]float64, n)
+			copy(aScalar, a)
+			saved := simdAddInplaceFloat64
+			simdAddInplaceFloat64 = nil
+			addInplaceFloat64(aScalar, b)
+			simdAddInplaceFloat64 = saved
+
+			addInplaceFloat64(a, b)
+
+			for i := range a {
+				diff := math.Abs(a[i] - aScalar[i])
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.15f scalar=%.15f diff=%.2e", i, a[i], aScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestSubInplaceFloat64_SIMDMatchesScalar verifies that the SIMD sub-inplace
+// kernel produces results matching the scalar fallback within float64 ULP noise.
+func TestSubInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
+	if simdSubInplaceFloat64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-10
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(11))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float64, n)
+			b := make([]float64, n)
+			for i := range a {
+				a[i] = rng.Float64()*2 - 1
+				b[i] = rng.Float64()*2 - 1
+			}
+
+			aScalar := make([]float64, n)
+			copy(aScalar, a)
+			saved := simdSubInplaceFloat64
+			simdSubInplaceFloat64 = nil
+			subInplaceFloat64(aScalar, b)
+			simdSubInplaceFloat64 = saved
+
+			subInplaceFloat64(a, b)
+
+			for i := range a {
+				diff := math.Abs(a[i] - aScalar[i])
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.15f scalar=%.15f diff=%.2e", i, a[i], aScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestMulInplaceFloat64_SIMDMatchesScalar verifies that the SIMD mul-inplace
+// kernel produces results matching the scalar fallback within float64 ULP noise.
+func TestMulInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
+	if simdMulInplaceFloat64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-10
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(12))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float64, n)
+			b := make([]float64, n)
+			for i := range a {
+				a[i] = rng.Float64()*2 - 1
+				b[i] = rng.Float64()*2 - 1
+			}
+
+			aScalar := make([]float64, n)
+			copy(aScalar, a)
+			saved := simdMulInplaceFloat64
+			simdMulInplaceFloat64 = nil
+			mulInplaceFloat64(aScalar, b)
+			simdMulInplaceFloat64 = saved
+
+			mulInplaceFloat64(a, b)
+
+			for i := range a {
+				diff := math.Abs(a[i] - aScalar[i])
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.15f scalar=%.15f diff=%.2e", i, a[i], aScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestDivInplaceFloat64_SIMDMatchesScalar verifies that the SIMD div-inplace
+// kernel produces results matching the scalar fallback within float64 ULP noise.
+func TestDivInplaceFloat64_SIMDMatchesScalar(t *testing.T) {
+	if simdDivInplaceFloat64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-10
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(13))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float64, n)
+			b := make([]float64, n)
+			for i := range a {
+				a[i] = rng.Float64()*2 - 1
+				b[i] = rng.Float64()*2 - 0.5
+			}
+
+			aScalar := make([]float64, n)
+			copy(aScalar, a)
+			saved := simdDivInplaceFloat64
+			simdDivInplaceFloat64 = nil
+			divInplaceFloat64(aScalar, b)
+			simdDivInplaceFloat64 = saved
+
+			divInplaceFloat64(a, b)
+
+			for i := range a {
+				diff := math.Abs(a[i] - aScalar[i])
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.15f scalar=%.15f diff=%.2e", i, a[i], aScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestAddVectorizedFloat64_SIMDMatchesScalar verifies that the SIMD add-vectorized
+// kernel produces results matching the scalar fallback within float64 ULP noise.
+func TestAddVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
+	if simdAddVectorizedFloat64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-10
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(14))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float64, n)
+			b := make([]float64, n)
+			for i := range a {
+				a[i] = rng.Float64()*2 - 1
+				b[i] = rng.Float64()*2 - 1
+			}
+
+			dstScalar := make([]float64, n)
+			saved := simdAddVectorizedFloat64
+			simdAddVectorizedFloat64 = nil
+			addVectorizedFloat64(dstScalar, a, b)
+			simdAddVectorizedFloat64 = saved
+
+			dstSIMD := make([]float64, n)
+			addVectorizedFloat64(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				diff := math.Abs(dstSIMD[i] - dstScalar[i])
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.15f scalar=%.15f diff=%.2e", i, dstSIMD[i], dstScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestSubVectorizedFloat64_SIMDMatchesScalar verifies that the SIMD sub-vectorized
+// kernel produces results matching the scalar fallback within float64 ULP noise.
+func TestSubVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
+	if simdSubVectorizedFloat64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-10
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(15))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float64, n)
+			b := make([]float64, n)
+			for i := range a {
+				a[i] = rng.Float64()*2 - 1
+				b[i] = rng.Float64()*2 - 1
+			}
+
+			dstScalar := make([]float64, n)
+			saved := simdSubVectorizedFloat64
+			simdSubVectorizedFloat64 = nil
+			subVectorizedFloat64(dstScalar, a, b)
+			simdSubVectorizedFloat64 = saved
+
+			dstSIMD := make([]float64, n)
+			subVectorizedFloat64(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				diff := math.Abs(dstSIMD[i] - dstScalar[i])
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.15f scalar=%.15f diff=%.2e", i, dstSIMD[i], dstScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestMulVectorizedFloat64_SIMDMatchesScalar verifies that the SIMD mul-vectorized
+// kernel produces results matching the scalar fallback within float64 ULP noise.
+func TestMulVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
+	if simdMulVectorizedFloat64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-10
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(16))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float64, n)
+			b := make([]float64, n)
+			for i := range a {
+				a[i] = rng.Float64()*2 - 1
+				b[i] = rng.Float64()*2 - 1
+			}
+
+			dstScalar := make([]float64, n)
+			saved := simdMulVectorizedFloat64
+			simdMulVectorizedFloat64 = nil
+			mulVectorizedFloat64(dstScalar, a, b)
+			simdMulVectorizedFloat64 = saved
+
+			dstSIMD := make([]float64, n)
+			mulVectorizedFloat64(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				diff := math.Abs(dstSIMD[i] - dstScalar[i])
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.15f scalar=%.15f diff=%.2e", i, dstSIMD[i], dstScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestDivVectorizedFloat64_SIMDMatchesScalar verifies that the SIMD div-vectorized
+// kernel produces results matching the scalar fallback within float64 ULP noise.
+func TestDivVectorizedFloat64_SIMDMatchesScalar(t *testing.T) {
+	if simdDivVectorizedFloat64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	const maxDiff = 1e-10
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(17))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]float64, n)
+			b := make([]float64, n)
+			for i := range a {
+				a[i] = rng.Float64()*2 - 1
+				b[i] = rng.Float64()*2 - 0.5
+			}
+
+			dstScalar := make([]float64, n)
+			saved := simdDivVectorizedFloat64
+			simdDivVectorizedFloat64 = nil
+			divVectorizedFloat64(dstScalar, a, b)
+			simdDivVectorizedFloat64 = saved
+
+			dstSIMD := make([]float64, n)
+			divVectorizedFloat64(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				diff := math.Abs(dstSIMD[i] - dstScalar[i])
+				if diff > maxDiff {
+					t.Fatalf("element[%d]: SIMD=%.15f scalar=%.15f diff=%.2e", i, dstSIMD[i], dstScalar[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestAddInplaceInt32_SIMDMatchesScalar verifies that the SIMD add-inplace
+// kernel produces bit-exact results matching the scalar fallback.
+func TestAddInplaceInt32_SIMDMatchesScalar(t *testing.T) {
+	if simdAddInplaceInt32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(20))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int32, n)
+			b := make([]int32, n)
+			for i := range a {
+				a[i] = int32(rng.Intn(1000) - 500)
+				b[i] = int32(rng.Intn(1000) - 500)
+			}
+
+			aScalar := make([]int32, n)
+			copy(aScalar, a)
+			saved := simdAddInplaceInt32
+			simdAddInplaceInt32 = nil
+			addInplaceInt32(aScalar, b)
+			simdAddInplaceInt32 = saved
+
+			addInplaceInt32(a, b)
+
+			for i := range a {
+				if a[i] != aScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, a[i], aScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSubInplaceInt32_SIMDMatchesScalar verifies that the SIMD sub-inplace
+// kernel produces bit-exact results matching the scalar fallback.
+func TestSubInplaceInt32_SIMDMatchesScalar(t *testing.T) {
+	if simdSubInplaceInt32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(21))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int32, n)
+			b := make([]int32, n)
+			for i := range a {
+				a[i] = int32(rng.Intn(1000) - 500)
+				b[i] = int32(rng.Intn(1000) - 500)
+			}
+
+			aScalar := make([]int32, n)
+			copy(aScalar, a)
+			saved := simdSubInplaceInt32
+			simdSubInplaceInt32 = nil
+			subInplaceInt32(aScalar, b)
+			simdSubInplaceInt32 = saved
+
+			subInplaceInt32(a, b)
+
+			for i := range a {
+				if a[i] != aScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, a[i], aScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestMulInplaceInt32_SIMDMatchesScalar verifies that the SIMD mul-inplace
+// kernel produces bit-exact results matching the scalar fallback.
+// Uses small values to avoid integer overflow.
+func TestMulInplaceInt32_SIMDMatchesScalar(t *testing.T) {
+	if simdMulInplaceInt32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(22))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int32, n)
+			b := make([]int32, n)
+			for i := range a {
+				a[i] = int32(rng.Intn(50) - 25)
+				b[i] = int32(rng.Intn(50) - 25)
+			}
+
+			aScalar := make([]int32, n)
+			copy(aScalar, a)
+			saved := simdMulInplaceInt32
+			simdMulInplaceInt32 = nil
+			mulInplaceInt32(aScalar, b)
+			simdMulInplaceInt32 = saved
+
+			mulInplaceInt32(a, b)
+
+			for i := range a {
+				if a[i] != aScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, a[i], aScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestAddVectorizedInt32_SIMDMatchesScalar verifies that the SIMD add-vectorized
+// kernel produces bit-exact results matching the scalar fallback.
+func TestAddVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
+	if simdAddVectorizedInt32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(23))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int32, n)
+			b := make([]int32, n)
+			for i := range a {
+				a[i] = int32(rng.Intn(1000) - 500)
+				b[i] = int32(rng.Intn(1000) - 500)
+			}
+
+			dstScalar := make([]int32, n)
+			saved := simdAddVectorizedInt32
+			simdAddVectorizedInt32 = nil
+			addVectorizedInt32(dstScalar, a, b)
+			simdAddVectorizedInt32 = saved
+
+			dstSIMD := make([]int32, n)
+			addVectorizedInt32(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				if dstSIMD[i] != dstScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, dstSIMD[i], dstScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSubVectorizedInt32_SIMDMatchesScalar verifies that the SIMD sub-vectorized
+// kernel produces bit-exact results matching the scalar fallback.
+func TestSubVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
+	if simdSubVectorizedInt32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(24))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int32, n)
+			b := make([]int32, n)
+			for i := range a {
+				a[i] = int32(rng.Intn(1000) - 500)
+				b[i] = int32(rng.Intn(1000) - 500)
+			}
+
+			dstScalar := make([]int32, n)
+			saved := simdSubVectorizedInt32
+			simdSubVectorizedInt32 = nil
+			subVectorizedInt32(dstScalar, a, b)
+			simdSubVectorizedInt32 = saved
+
+			dstSIMD := make([]int32, n)
+			subVectorizedInt32(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				if dstSIMD[i] != dstScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, dstSIMD[i], dstScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestMulVectorizedInt32_SIMDMatchesScalar verifies that the SIMD mul-vectorized
+// kernel produces bit-exact results matching the scalar fallback.
+// Uses small values to avoid integer overflow.
+func TestMulVectorizedInt32_SIMDMatchesScalar(t *testing.T) {
+	if simdMulVectorizedInt32 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(25))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int32, n)
+			b := make([]int32, n)
+			for i := range a {
+				a[i] = int32(rng.Intn(50) - 25)
+				b[i] = int32(rng.Intn(50) - 25)
+			}
+
+			dstScalar := make([]int32, n)
+			saved := simdMulVectorizedInt32
+			simdMulVectorizedInt32 = nil
+			mulVectorizedInt32(dstScalar, a, b)
+			simdMulVectorizedInt32 = saved
+
+			dstSIMD := make([]int32, n)
+			mulVectorizedInt32(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				if dstSIMD[i] != dstScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, dstSIMD[i], dstScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestAddInplaceInt64_SIMDMatchesScalar verifies that the SIMD add-inplace
+// kernel produces bit-exact results matching the scalar fallback.
+func TestAddInplaceInt64_SIMDMatchesScalar(t *testing.T) {
+	if simdAddInplaceInt64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(30))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int64, n)
+			b := make([]int64, n)
+			for i := range a {
+				a[i] = rng.Int63n(1000) - 500
+				b[i] = rng.Int63n(1000) - 500
+			}
+
+			aScalar := make([]int64, n)
+			copy(aScalar, a)
+			saved := simdAddInplaceInt64
+			simdAddInplaceInt64 = nil
+			addInplaceInt64(aScalar, b)
+			simdAddInplaceInt64 = saved
+
+			addInplaceInt64(a, b)
+
+			for i := range a {
+				if a[i] != aScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, a[i], aScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSubInplaceInt64_SIMDMatchesScalar verifies that the SIMD sub-inplace
+// kernel produces bit-exact results matching the scalar fallback.
+func TestSubInplaceInt64_SIMDMatchesScalar(t *testing.T) {
+	if simdSubInplaceInt64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(31))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int64, n)
+			b := make([]int64, n)
+			for i := range a {
+				a[i] = rng.Int63n(1000) - 500
+				b[i] = rng.Int63n(1000) - 500
+			}
+
+			aScalar := make([]int64, n)
+			copy(aScalar, a)
+			saved := simdSubInplaceInt64
+			simdSubInplaceInt64 = nil
+			subInplaceInt64(aScalar, b)
+			simdSubInplaceInt64 = saved
+
+			subInplaceInt64(a, b)
+
+			for i := range a {
+				if a[i] != aScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, a[i], aScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestMulInplaceInt64_SIMDMatchesScalar verifies that the SIMD mul-inplace
+// kernel produces bit-exact results matching the scalar fallback.
+// Uses small values to avoid integer overflow.
+func TestMulInplaceInt64_SIMDMatchesScalar(t *testing.T) {
+	if simdMulInplaceInt64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(32))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int64, n)
+			b := make([]int64, n)
+			for i := range a {
+				a[i] = rng.Int63n(50) - 25
+				b[i] = rng.Int63n(50) - 25
+			}
+
+			aScalar := make([]int64, n)
+			copy(aScalar, a)
+			saved := simdMulInplaceInt64
+			simdMulInplaceInt64 = nil
+			mulInplaceInt64(aScalar, b)
+			simdMulInplaceInt64 = saved
+
+			mulInplaceInt64(a, b)
+
+			for i := range a {
+				if a[i] != aScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, a[i], aScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestAddVectorizedInt64_SIMDMatchesScalar verifies that the SIMD add-vectorized
+// kernel produces bit-exact results matching the scalar fallback.
+func TestAddVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
+	if simdAddVectorizedInt64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(33))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int64, n)
+			b := make([]int64, n)
+			for i := range a {
+				a[i] = rng.Int63n(1000) - 500
+				b[i] = rng.Int63n(1000) - 500
+			}
+
+			dstScalar := make([]int64, n)
+			saved := simdAddVectorizedInt64
+			simdAddVectorizedInt64 = nil
+			addVectorizedInt64(dstScalar, a, b)
+			simdAddVectorizedInt64 = saved
+
+			dstSIMD := make([]int64, n)
+			addVectorizedInt64(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				if dstSIMD[i] != dstScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, dstSIMD[i], dstScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSubVectorizedInt64_SIMDMatchesScalar verifies that the SIMD sub-vectorized
+// kernel produces bit-exact results matching the scalar fallback.
+func TestSubVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
+	if simdSubVectorizedInt64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(34))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int64, n)
+			b := make([]int64, n)
+			for i := range a {
+				a[i] = rng.Int63n(1000) - 500
+				b[i] = rng.Int63n(1000) - 500
+			}
+
+			dstScalar := make([]int64, n)
+			saved := simdSubVectorizedInt64
+			simdSubVectorizedInt64 = nil
+			subVectorizedInt64(dstScalar, a, b)
+			simdSubVectorizedInt64 = saved
+
+			dstSIMD := make([]int64, n)
+			subVectorizedInt64(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				if dstSIMD[i] != dstScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, dstSIMD[i], dstScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// TestMulVectorizedInt64_SIMDMatchesScalar verifies that the SIMD mul-vectorized
+// kernel produces bit-exact results matching the scalar fallback.
+// Uses small values to avoid integer overflow.
+func TestMulVectorizedInt64_SIMDMatchesScalar(t *testing.T) {
+	if simdMulVectorizedInt64 == nil {
+		t.Skip("SIMD kernel not available")
+	}
+
+	sizes := []int{1, 3, 4, 7, 8, 13, 16, 31, 32, 64, 100, 128, 256, 1024}
+
+	rng := rand.New(rand.NewSource(35))
+	for _, n := range sizes {
+		t.Run("n="+itoa(n), func(t *testing.T) {
+			a := make([]int64, n)
+			b := make([]int64, n)
+			for i := range a {
+				a[i] = rng.Int63n(50) - 25
+				b[i] = rng.Int63n(50) - 25
+			}
+
+			dstScalar := make([]int64, n)
+			saved := simdMulVectorizedInt64
+			simdMulVectorizedInt64 = nil
+			mulVectorizedInt64(dstScalar, a, b)
+			simdMulVectorizedInt64 = saved
+
+			dstSIMD := make([]int64, n)
+			mulVectorizedInt64(dstSIMD, a, b)
+
+			for i := range dstSIMD {
+				if dstSIMD[i] != dstScalar[i] {
+					t.Fatalf("element[%d]: SIMD=%d scalar=%d", i, dstSIMD[i], dstScalar[i])
+				}
+			}
+		})
+	}
+}
+
+// itoa is a minimal int-to-string helper for subtest names.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
This PR adds the following SIMD support to the non-broadcasting arithmetic operations (e.g. addInplace, addVectorized, subInplace, etc.)

| dtype   | op  | AVX | AVX2 | AVX512 |
|---------|-----|-----|------|--------|
| int32   | add |     | x    | x      |
| int32   | sub |     | x    | x      |
| int32   | mul |     | x    | x      |
| int32   | div |     |      |        |
| int64   | add |     | x    | x      |
| int64   | sub |     | x    | x      |
| int64   | mul |     |      | x      |
| int64   | div |     |      |        |
| float32 | add | x   |      | x      |
| float32 | sub | x   |      | x      |
| float32 | mul | x   |      | x      |
| float32 | div | x   |      | x      |
| float64 | add | x   |      | x      |
| float64 | sub | x   |      | x      |
| float64 | mul | x   |      | x      |
| float64 | div | x   |      | x      |

Benchmarks on my machine (13th Gen Intel(R) Core(TM) i5-13600K) from running `GOEXPERIMENT=simd go test -bench='(Inplace|Vectorized)' -benchmem ./...`:

**F32**

| Operation | Scalar | SIMD | Speedup |
|-----------|--------|------|---------|
| `AddInplaceF32` | 246 ns | 71 ns | 3.5x |
| `AddVectorizedF32` | 370 ns | 69 ns | 5.4x |
| `DivInplaceF32` | 603 ns | 126 ns | 4.8x |
| `DivVectorizedF32` | 603 ns | 126 ns | 4.8x |
| `MulInplaceF32` | 13.18 us | 3.12 us | 4.2x |
| `MulVectorizedF32` | 365 ns | 70 ns | 5.2x |
| `SubInplaceF32` | 247 ns | 70 ns | 3.5x |
| `SubVectorizedF32` | 311 ns | 68 ns | 4.6x |

**F64**

| Operation | Scalar | SIMD | Speedup |
|-----------|--------|------|---------|
| `AddInplaceF64` | 278 ns | 138 ns | 2.0x |
| `AddVectorizedF64` | 311 ns | 146 ns | 2.1x |
| `DivInplaceF64` | 805 ns | 402 ns | 2.0x |
| `DivVectorizedF64` | 804 ns | 402 ns | 2.0x |
| `MulInplaceF64` | 12.66 us | 5.84 us | 2.2x |
| `MulVectorizedF64` | 311 ns | 151 ns | 2.1x |
| `SubInplaceF64` | 248 ns | 135 ns | 1.8x |
| `SubVectorizedF64` | 363 ns | 156 ns | 2.3x |

**I32**

| Operation | Scalar | SIMD | Speedup |
|-----------|--------|------|---------|
| `AddInplaceI32` | 236 ns | 72 ns | 3.3x |
| `AddVectorizedI32` | 375 ns | 77 ns | 4.9x |
| `MulInplaceI32` | 249 ns | 76 ns | 3.3x |
| `MulVectorizedI32` | 367 ns | 77 ns | 4.8x |
| `SubInplaceI32` | 211 ns | 73 ns | 2.9x |
| `SubVectorizedI32` | 312 ns | 77 ns | 4.1x |

**I64**

| Operation | Scalar | SIMD | Speedup |
|-----------|--------|------|---------|
| `AddInplaceI64` | 211 ns | 132 ns | 1.6x |
| `AddVectorizedI64` | 312 ns | 150 ns | 2.1x |
| `MulInplaceI64` | 249 ns | - | - |
| `MulVectorizedI64` | 310 ns | - | - |
| `SubInplaceI64` | 229 ns | 142 ns | 1.6x |
| `SubVectorizedI64` | 369 ns | 148 ns | 2.5x |
