### PR TITLE
v0.9.5: wgpu v0.30.1 + gpucontext dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Born ML Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5] - 2026-06-16
+
+### Changed
+
+- **wgpu upgraded** v0.30.0 → v0.30.1
+- **gpucontext** v0.21.0 added as transitive dependency (via wgpu) — foundation for future gogpu/compute integration (ADR-008)
+
 ## [0.9.4] - 2026-06-15
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/wgpu v0.30.0
+	github.com/gogpu/wgpu v0.30.1
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/stretchr/testify v1.11.1
 )
@@ -14,6 +14,7 @@ require (
 	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/go-webgpu/goffi v0.5.3 // indirect
 	github.com/go-webgpu/webgpu v0.5.2 // indirect
+	github.com/gogpu/gpucontext v0.21.0 // indirect
 	github.com/gogpu/naga v0.17.15 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,12 +6,14 @@ github.com/go-webgpu/goffi v0.5.3 h1:Ckc94SdHO42bIb0oEapRIcv+jKjhjGJfb9zPEvNKC7U
 github.com/go-webgpu/goffi v0.5.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
+github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
+github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.15 h1:uyy4bc8wYlvDaYOpmCBYrJ+d+e7ZqP2BN36csmRVs7o=
 github.com/gogpu/naga v0.17.15/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.30.0 h1:EXMoe9kx7VOEmH0QV/OWoY+pOt4jp852n2f2ne6xnMg=
-github.com/gogpu/wgpu v0.30.0/go.mod h1:ELqMwPTkfFa8WlnxV4JuWaI718ufE2EXnJZV1WNTJbE=
+github.com/gogpu/wgpu v0.30.1 h1:dZ6FeOiKNlimaDWiiUneLExgbLqZDTu+acqajAM7gWw=
+github.com/gogpu/wgpu v0.30.1/go.mod h1:D2GQZtdBMBoPbkOUTjDm2xoO6j7dCzeTBZZOHjMhWoU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pkoukk/tiktoken-go v0.1.8 h1:85ENo+3FpWgAACBaEUVp+lctuTcYUO7BtmfhlN/QTRo=


### PR DESCRIPTION
## Summary

- gogpu/wgpu v0.30.0 → **v0.30.1**
- gogpu/gpucontext **v0.21.0** added as transitive dependency (via wgpu)

gpucontext is the foundation for future gogpu/compute integration (ADR-008) — shared GPU context, adapter management, device lifecycle.

### Verified
- `go build ./...` — Pure Go ✅
- `go build -tags=rust ./...` — Rust ✅
- `GOGPU_GRAPHICS_API=software` — Software ✅
- All tests pass

## Test plan
- [x] Three build modes
- [x] Unit tests
- [x] Software backend training example
- [ ] CI (Ubuntu/macOS/Windows)